### PR TITLE
Ebay authentication setup

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from apps.api.routers import auth, ebay, health, images, intake, internal
+from apps.api.routers import auth, ebay, health, images, intake, internal, pages
 from packages.config import configure_tracing
 
 # Activate LangSmith tracing before any LangGraph graph is compiled
@@ -17,3 +17,4 @@ app.include_router(ebay.router)
 app.include_router(intake.router)
 app.include_router(images.router)
 app.include_router(internal.router)
+app.include_router(pages.router)

--- a/apps/api/routers/ebay.py
+++ b/apps/api/routers/ebay.py
@@ -1,9 +1,11 @@
 import json
+import logging
 import secrets
 import uuid
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,11 +21,16 @@ from packages.platform_adapters.ebay.oauth import (
     token_expiry,
 )
 
+logger = logging.getLogger(__name__)
+
 # APIRouter for eBay OAuth endpoints
 router = APIRouter(prefix="/auth/ebay", tags=["ebay-oauth"])
 
 # Time-to-live for OAuth state nonce in Redis (10 minutes)
 _STATE_TTL = 600  # seconds — how long the state nonce lives in Redis
+
+# Frontend page the seller is redirected to after OAuth completes
+_FRONTEND_CHAT = "/chat"
 
 
 def _redis():
@@ -65,14 +72,28 @@ async def ebay_connect(seller: Seller = Depends(get_current_seller)) -> dict:  #
 
 @router.get("/callback")
 async def ebay_callback(
-    code: str = Query(...),
-    state: str = Query(...),
+    code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    declined: str | None = Query(default=None),
     session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> dict:
+) -> RedirectResponse:
     """
     eBay redirects the seller's browser here after consent.
-    Validates the state nonce, exchanges the code, encrypts and persists the tokens.
+
+    On success: validates state, exchanges the code, encrypts tokens,
+    and redirects back to the frontend chat page with ?ebay=connected.
+
+    On decline: eBay redirects without a code. We redirect to ?ebay=declined.
     """
+    # Handle declined consent
+    if declined or code is None:
+        logger.info("eBay OAuth consent was declined")
+        return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=declined", status_code=302)
+
+    if state is None:
+        logger.warning("eBay OAuth callback received without state parameter")
+        return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=error", status_code=302)
+
     r = _redis()
     try:
         # Retrieve and delete the stored state data atomically
@@ -81,9 +102,8 @@ async def ebay_callback(
         await r.aclose()
 
     if stored is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired state"
-        )
+        logger.warning("eBay OAuth callback received with invalid or expired state")
+        return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=error", status_code=302)
 
     # Parse stored data to get seller ID and code verifier
     data = json.loads(stored)
@@ -94,10 +114,11 @@ async def ebay_callback(
         # Exchange authorization code for access token
         token_data = await exchange_code(code, code_verifier)
     except httpx.HTTPStatusError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"eBay token exchange failed: {exc.response.text}",
-        ) from exc
+        logger.error("eBay token exchange failed: %s", exc.response.text)
+        return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=error", status_code=302)
+    except Exception:
+        logger.exception("eBay token exchange failed unexpectedly")
+        return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=error", status_code=302)
 
     # Extract token details
     access_token: str = token_data["access_token"]
@@ -125,5 +146,31 @@ async def ebay_callback(
     # Commit the changes to the database
     await session.commit()
 
-    # Return success response with expiry info
-    return {"status": "connected", "platform": "ebay", "expires_at": expires_at.isoformat()}
+    logger.info("eBay OAuth tokens saved for seller %s", seller_id)
+
+    # Redirect back to the frontend chat page with success indicator
+    return RedirectResponse(url=f"{_FRONTEND_CHAT}?ebay=connected", status_code=302)
+
+
+@router.get("/status")
+async def ebay_status(
+    seller: Seller = Depends(get_current_seller),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> dict:
+    """
+    Check whether the current seller has a connected eBay account.
+    Returns connection status and token expiry if connected.
+    """
+    cred = await session.scalar(
+        select(PlatformCredential).where(
+            PlatformCredential.seller_id == seller.id,
+            PlatformCredential.platform == Platform.ebay,
+        )
+    )
+    if cred is None:
+        return {"connected": False}
+
+    return {
+        "connected": True,
+        "expires_at": cred.expires_at.isoformat() if cred.expires_at else None,
+    }

--- a/apps/api/routers/pages.py
+++ b/apps/api/routers/pages.py
@@ -1,0 +1,129 @@
+"""Static legal pages required by eBay's RuName configuration.
+
+Serves HTML directly so these URLs can be set in the eBay Developer Portal
+without depending on the frontend being deployed.
+"""
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter(tags=["pages"])
+
+_STYLE = """
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+         max-width: 720px; margin: 40px auto; padding: 0 20px; color: #1a1a1a;
+         line-height: 1.7; }
+  h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+  h2 { font-size: 1.2rem; margin-top: 2rem; }
+  p, li { font-size: 0.95rem; color: #333; }
+  a { color: #2563eb; }
+  .updated { font-size: 0.85rem; color: #888; margin-bottom: 2rem; }
+</style>
+"""
+
+
+@router.get("/privacy-policy", response_class=HTMLResponse)
+async def privacy_policy() -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Privacy Policy — SalesRep</title>{_STYLE}</head>
+<body>
+<h1>Privacy Policy</h1>
+<p class="updated">Last updated: 2 May 2025</p>
+
+<p>SalesRep ("we", "our", "us") is a multi-agent AI selling assistant that helps
+sellers list and manage items on online marketplaces. This policy explains how we
+handle your data.</p>
+
+<h2>1. Information We Collect</h2>
+<ul>
+  <li><strong>Account information</strong> — email address and a hashed password when
+  you sign up.</li>
+  <li><strong>Item data</strong> — item names, descriptions, images, and pricing
+  information you provide through the intake chat.</li>
+  <li><strong>Platform tokens</strong> — when you connect an eBay account, we store
+  encrypted OAuth tokens so we can list items and manage messages on your behalf.
+  We never store your eBay password.</li>
+  <li><strong>Usage data</strong> — server logs that include IP addresses and request
+  timestamps for security and debugging purposes.</li>
+</ul>
+
+<h2>2. How We Use Your Information</h2>
+<ul>
+  <li>To provide the selling assistant service (listing items, pricing, buyer communication).</li>
+  <li>To authenticate you and maintain your session.</li>
+  <li>To interact with eBay APIs on your behalf using your authorised tokens.</li>
+  <li>To improve the service and fix bugs.</li>
+</ul>
+
+<h2>3. Data Sharing</h2>
+<p>We do not sell your personal data. We share data only with:</p>
+<ul>
+  <li><strong>eBay</strong> — item listings and messages, via their official APIs, as
+  authorised by you.</li>
+  <li><strong>AI providers</strong> — item descriptions and chat messages are sent to
+  our AI model provider (OpenAI / Azure OpenAI) for processing. No eBay credentials
+  are included in AI requests.</li>
+</ul>
+
+<h2>4. Data Security</h2>
+<p>OAuth tokens are encrypted at rest using AES-256-GCM. Passwords are hashed with
+bcrypt. All communication uses HTTPS.</p>
+
+<h2>5. Data Retention</h2>
+<p>We retain your account data and item data for as long as your account is active.
+You can request deletion by contacting us.</p>
+
+<h2>6. Your Rights</h2>
+<p>You may request access to, correction of, or deletion of your personal data at any
+time by emailing us.</p>
+
+<h2>7. Contact</h2>
+<p>For privacy questions, contact us at
+<a href="mailto:privacy@devopslearn.store">privacy@devopslearn.store</a>.</p>
+</body></html>"""
+
+
+@router.get("/terms", response_class=HTMLResponse)
+async def terms_of_service() -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Terms of Service — SalesRep</title>{_STYLE}</head>
+<body>
+<h1>Terms of Service</h1>
+<p class="updated">Last updated: 2 May 2025</p>
+
+<p>By using SalesRep you agree to the following terms.</p>
+
+<h2>1. Service Description</h2>
+<p>SalesRep is an AI-powered tool that assists with listing and selling items on
+eBay and other marketplaces. The service provides pricing recommendations and
+automated listing creation based on information you provide.</p>
+
+<h2>2. Your Responsibilities</h2>
+<ul>
+  <li>You are responsible for the accuracy of item descriptions and images you provide.</li>
+  <li>You must have the legal right to sell items listed through the service.</li>
+  <li>You are responsible for complying with eBay's terms of service and applicable laws.</li>
+</ul>
+
+<h2>3. Pricing Recommendations</h2>
+<p>Pricing suggestions are based on comparable listings and machine learning models.
+They are recommendations only — you are free to set any price you choose. We do not
+guarantee the accuracy of pricing estimates.</p>
+
+<h2>4. Platform Access</h2>
+<p>When you connect your eBay account, you authorise SalesRep to create listings, manage
+inventory, and respond to buyer messages on your behalf. You can revoke this access at
+any time through your eBay account settings.</p>
+
+<h2>5. Limitation of Liability</h2>
+<p>SalesRep is provided "as is". We are not liable for any losses resulting from
+pricing recommendations, listing errors, or platform outages.</p>
+
+<h2>6. Contact</h2>
+<p>Questions? Email <a href="mailto:support@devopslearn.store">support@devopslearn.store</a>.</p>
+</body></html>"""

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useRef, useState, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { api, PricingResult } from "@/lib/api";
 
 interface Message {
@@ -122,14 +122,39 @@ function PricingSpinner() {
   );
 }
 
-export default function ChatPage() {
+/* ── Toast notification ────────────────────────────────────────────── */
+
+function Toast({ message, type, onClose }: { message: string; type: "success" | "error" | "info"; onClose: () => void }) {
+  const bg = type === "success" ? "bg-emerald-600" : type === "error" ? "bg-rose-600" : "bg-blue-600";
+
+  useEffect(() => {
+    const t = setTimeout(onClose, 5000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div className={`fixed top-4 right-4 z-50 ${bg} text-white rounded-xl px-5 py-3 shadow-lg flex items-center gap-3 animate-[slideIn_0.3s_ease-out]`}>
+      <span className="text-sm font-medium">{message}</span>
+      <button onClick={onClose} className="text-white/70 hover:text-white text-lg leading-none">&times;</button>
+    </div>
+  );
+}
+
+/* ── Main page ─────────────────────────────────────────────────────── */
+
+function ChatPageInner() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [messages, setMessages] = useState<Message[]>([]);
   const [itemId, setItemId] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [connectingEbay, setConnectingEbay] = useState(false);
+
+  // eBay connection state
+  const [ebayConnected, setEbayConnected] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
 
   // Pricing state
   const [pricingResult, setPricingResult] = useState<PricingResult | null>(null);
@@ -149,7 +174,27 @@ export default function ChatPage() {
       role: "assistant",
       content: "Hi! I'm your AI selling assistant. Tell me about an item you'd like to sell — what is it?",
     }]);
-  }, [router]);
+
+    // Check eBay connection status on mount
+    api.ebayStatus()
+      .then((res) => setEbayConnected(res.connected))
+      .catch(() => {}); // Silently fail — not critical
+
+    // Handle eBay OAuth callback query params
+    const ebayParam = searchParams.get("ebay");
+    if (ebayParam === "connected") {
+      setEbayConnected(true);
+      setToast({ message: "eBay account connected successfully!", type: "success" });
+      // Clean up the URL without reloading
+      window.history.replaceState({}, "", "/chat");
+    } else if (ebayParam === "declined") {
+      setToast({ message: "eBay connection was declined. You can try again anytime.", type: "info" });
+      window.history.replaceState({}, "", "/chat");
+    } else if (ebayParam === "error") {
+      setToast({ message: "Something went wrong connecting to eBay. Please try again.", type: "error" });
+      window.history.replaceState({}, "", "/chat");
+    }
+  }, [router, searchParams]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -189,7 +234,7 @@ export default function ChatPage() {
       const { authorization_url } = await api.ebayConnect();
       window.location.href = authorization_url;
     } catch (err: unknown) {
-      alert(err instanceof Error ? err.message : "Failed to start eBay connection");
+      setToast({ message: err instanceof Error ? err.message : "Failed to start eBay connection", type: "error" });
       setConnectingEbay(false);
     }
   }
@@ -259,17 +304,32 @@ export default function ChatPage() {
 
   return (
     <div className="flex h-screen bg-gray-50">
+      {/* Toast notification */}
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+
       {/* Sidebar */}
       <aside className="w-56 bg-white border-r border-gray-200 flex flex-col p-4 gap-3 shrink-0">
         <p className="font-semibold text-sm">SalesRep</p>
         <div className="flex-1" />
-        <button
-          onClick={handleConnectEbay}
-          disabled={connectingEbay}
-          className="w-full text-sm bg-blue-600 text-white rounded-lg px-3 py-2 hover:bg-blue-700 disabled:opacity-50 transition-colors"
-        >
-          {connectingEbay ? "Redirecting…" : "Connect eBay"}
-        </button>
+
+        {/* eBay connection button / status */}
+        {ebayConnected ? (
+          <div className="w-full text-sm bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-lg px-3 py-2 flex items-center gap-2">
+            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <span>eBay Connected</span>
+          </div>
+        ) : (
+          <button
+            onClick={handleConnectEbay}
+            disabled={connectingEbay}
+            className="w-full text-sm bg-blue-600 text-white rounded-lg px-3 py-2 hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {connectingEbay ? "Redirecting…" : "Connect eBay"}
+          </button>
+        )}
+
         <button
           onClick={logout}
           className="w-full text-left text-sm text-gray-400 hover:text-gray-700 px-1 transition-colors"
@@ -369,5 +429,13 @@ export default function ChatPage() {
         </aside>
       )}
     </div>
+  );
+}
+
+export default function ChatPage() {
+  return (
+    <Suspense fallback={<div className="flex h-screen items-center justify-center bg-gray-50 text-gray-400">Loading…</div>}>
+      <ChatPageInner />
+    </Suspense>
   );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -64,6 +64,11 @@ export interface PricingResult {
   comparables: Comparable[];
 }
 
+export interface EbayStatusResponse {
+  connected: boolean;
+  expires_at: string | null;
+}
+
 export const api = {
   signup: (email: string, password: string) =>
     request<TokenResponse>("/auth/signup", {
@@ -79,6 +84,9 @@ export const api = {
 
   ebayConnect: () =>
     request<{ authorization_url: string }>("/auth/ebay/connect"),
+
+  ebayStatus: () =>
+    request<EbayStatusResponse>("/auth/ebay/status"),
 
   sendMessage: (content: string, itemId?: string | null) =>
     request<MessageResponse>("/agent/intake/message", {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,10 +2,25 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   async rewrites() {
+    const api = process.env.API_URL ?? "http://localhost:8000";
     return [
       {
         source: "/api/:path*",
-        destination: `${process.env.API_URL ?? "http://localhost:8000"}/:path*`,
+        destination: `${api}/:path*`,
+      },
+      // eBay OAuth callback comes directly to the browser — proxy to backend
+      {
+        source: "/auth/ebay/callback",
+        destination: `${api}/auth/ebay/callback`,
+      },
+      // Legal pages served by the backend
+      {
+        source: "/privacy-policy",
+        destination: `${api}/privacy-policy`,
+      },
+      {
+        source: "/terms",
+        destination: `${api}/terms`,
       },
     ];
   },


### PR DESCRIPTION
## eBay OAuth — End-to-End Connection Flow
Wires up the full eBay OAuth PKCE flow so sellers can connect their eBay account from the sidebar, handles the post-consent redirect gracefully, and adds the legal pages required by eBay's RuName configuration.

## What's changed
Backend (apps/api/)

routers/ebay.py — Callback endpoint now issues a RedirectResponse instead of returning raw JSON. After eBay redirects the seller's browser back, they land on /chat?ebay=connected (success) or /chat?ebay=declined (consent denied) or /chat?ebay=error (token exchange failure). Added GET /auth/ebay/status so the frontend can check connection state on page load. Both code and state are optional query params so eBay's declined redirect (which omits them) no longer returns a 422.

routers/pages.py (new) — Serves GET /privacy-policy and GET /terms as self-contained HTML pages, required by eBay's RuName settings. No frontend dependency — these work even if the Next.js app is down.
main.py — Registers the new pages router.
Frontend (apps/web/)

lib/api.ts — Added ebayStatus() method (GET /auth/ebay/status) and the EbayStatusResponse interface.
app/chat/page.tsx — On mount: calls ebayStatus() to hydrate sidebar state, and reads ?ebay= query param to show toast notifications for connected, declined, and error outcomes. The sidebar "Connect eBay" button swaps to a green "eBay Connected ✓" badge once connected. URL is cleaned up after reading the param (replaceState).

app/globals.css — Added @keyframes slideIn for the toast entrance animation.

next.config.ts — Added rewrites for /auth/ebay/callback, /privacy-policy, and /terms → backend, so all three URLs are reachable under the same domain.

## Config

.env — EBAY_REDIRECT_URI updated to https://devopslearn.store/auth/ebay/callback.

Post-deploy checklist

After deploying, update the eBay RuName in the Developer Portal:

Auth Accepted URL: https://devopslearn.store/auth/ebay/callback
Auth Declined URL: https://devopslearn.store/auth/ebay/callback?declined=true
Privacy Policy URL: https://devopslearn.store/privacy-policy

## Testing
Smoke-tested locally — signup, /chat sidebar button, /privacy-policy, /terms, ?ebay=connected green toast, and ?ebay=declined info toast all verified working. Backend logs confirmed all endpoints returning 200 OK.

