### PR TITLE
Fix pricing agent not calculating price

### DIFF
--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -115,7 +115,7 @@ def _get_sentence_model():
 _DEFAULT_FLOOR_RATIO = 0.70
 _MODEL_WEIGHT = 0.60  # model 60%, live comparable median 40%
 _TARGET_COMPARABLES = 20
-_MAX_SEARCH_ROUNDS = 3
+_MAX_SEARCH_ROUNDS = 2
 
 # ---------------------------------------------------------------------------
 # Condition → v3 ordinal  (mirrors notebook CONDITION_ORDINAL)
@@ -338,8 +338,8 @@ async def _collect_comparables(
         seen_ids.update(c.item_id for c in raw)
 
         if not new_candidates:
-            logger.info("Round %d returned no new candidates — stopping", round_num)
-            break
+            logger.info("Round %d returned no new candidates — continuing", round_num)
+            continue
 
         # ── LLM relevance gate ─────────────────────────────────────────────
         valid, rejected = await validate_comparables(

--- a/packages/agents/pricing/comparable_filter.py
+++ b/packages/agents/pricing/comparable_filter.py
@@ -205,7 +205,7 @@ async def validate_comparables(
 # Keyword extraction from validated comparables
 # ---------------------------------------------------------------------------
 
-def extract_keywords_from_comparables(comparables: list[Comparable], top_n: int = 8) -> str:
+def extract_keywords_from_comparables(comparables: list[Comparable], top_n: int = 5) -> str:
     """Extract the most common high-signal words from validated comparable titles.
 
     Counts word frequency across all kept titles, skips generic stopwords,

--- a/packages/platform_adapters/ebay/browse.py
+++ b/packages/platform_adapters/ebay/browse.py
@@ -217,7 +217,6 @@ async def search_comparables(
     params: dict[str, str | int] = {
         "q": query,
         "limit": min(limit, 200),  # API max is 200
-        "sort": "price",
     }
 
     # Apply category filter when available — this is the single most effective


### PR DESCRIPTION
eBay Search Returning Cheapest Junk: In packages/platform_adapters/ebay/browse.py, the search_comparables function was passing "sort": "price". This forced eBay to return the absolute cheapest items matching the query first (which usually ends up being phone cases, boxes, or broken devices). The LLM filter correctly identified these as irrelevant and rejected all of them, leaving 0 valid comparables in the pool. I've removed the price sort parameter, allowing eBay to return "Best Match" results which are significantly more accurate.

Early Loop Exit Bug: In packages/agents/pricing/agent.py, if a round returned 0 new candidates (because they were either not found or all rejected), the loop would break out completely and fail. I've updated it to continue, so the multi-round adaptive fallback search will properly engage if round 0 struggles.
Refinement Was Too Sharp: You were right about the refinement being too sharp! The extract_keywords_from_comparables function in comparable_filter.py was pulling the top 8 keywords to formulate the Round 1 fallback query. An 8-keyword query on eBay is often too restrictive and yields zero results. I've reduced this to pull only the top 5 keywords (top_n = 5), smoothing out the query.

Reduced Search Rounds: To address the agent taking too long, I've reduced _MAX_SEARCH_ROUNDS from 3 to 2. With the fixes above, we should hit the 20 target comparables easily in the first two rounds without needing to drag the process out into a 3rd extreme-fallback round.

The pricing agent will now quickly find solid comparables using Best Match, properly fall back using a cleaner keyword string if it needs to, and evaluate much more efficiently! Give it another run and it should calculate the accurate price reliably now.

