### PR TITLE
feat: add keyword-based category inference fallback to intake graph a…

### DIFF
--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -28,6 +28,7 @@ from packages.agents.intake.tools import (
     CATEGORY_LIST,
     TOOL_DEFINITIONS,
     execute_tool,
+    infer_category,
 )
 from packages.config import settings
 from packages.db.models import Item, ItemCondition, ItemImage, ItemStatus
@@ -167,12 +168,25 @@ async def _plan_next_step(
     # Check for missing fields
     missing = _missing_fields(item)
     if missing:
+        # The LLM occasionally skips the category record step (Azure GPT-5
+        # doesn't always honour the "infer category" instruction). Before
+        # bouncing the canned question back at the seller, try to infer it
+        # from the item name ourselves.
+        if "category" in missing and item.name:
+            inferred = infer_category(item.name)
+            if inferred:
+                item.category = inferred
+                await session.flush()
+                missing = _missing_fields(item)
+
         # If only description/name missing, defer to LLM so it calls generate_listing
         if missing == ["description"]:
             return None, False, False
         if missing == ["name"]:
             return None, False, False
         if set(missing) == {"name", "description"}:
+            return None, False, False
+        if not missing:
             return None, False, False
 
         # Otherwise ask questions to fill in the missing fields

--- a/packages/agents/intake/tools.py
+++ b/packages/agents/intake/tools.py
@@ -60,6 +60,48 @@ CATEGORY_LIST = [
     "Other",
 ]
 
+
+# Keyword → category fallback used when the LLM skips the category inference
+# step. Order matters where overlap exists (e.g. specific patterns first).
+_CATEGORY_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
+    (("headphone", "earbud", "earphone", "airpod"), "Headphones"),
+    (("soundbar", "subwoofer", "speaker"), "Speakers"),
+    (("macbook", "thinkpad", "laptop", "notebook computer"), "Laptops"),
+    (("ipad", "kindle", "tablet"), "Tablets"),
+    (("iphone", "galaxy s", "pixel ", "smartphone", "phone"), "Phones"),
+    (("monitor", "display"), "Monitors"),
+    (("trainer", "sneaker", "running shoe"), "Trainers"),
+    (("shoe", "boot", "loafer", "sandal"), "Shoes"),
+    (("watch", "smartwatch"), "Watches"),
+    (("dslr", "mirrorless camera", "camera"), "Cameras"),
+    (("camera lens", "prime lens", "zoom lens"), "Camera Lenses"),
+    (("xbox", "playstation", "ps5", "ps4", "nintendo switch"), "Gaming Consoles"),
+    (("video game", "game cartridge"), "Video Games"),
+    (("guitar", "piano", "violin", "drum kit"), "Musical Instruments"),
+    (("bicycle", "bike"), "Bicycles"),
+    (("treadmill", "dumbbell", "kettlebell"), "Fitness Equipment"),
+    (("rucksack", "backpack", "suitcase", "luggage"), "Bags & Luggage"),
+    (("necklace", "bracelet", "earring", "ring"), "Jewellery"),
+    (("imac", "desktop computer", "desktop pc"), "Desktop Computers"),
+)
+
+
+def infer_category(name: str) -> str | None:
+    """Best-effort category inference from item name.
+
+    Returns the matching category from `CATEGORY_LIST`, or None if no keyword
+    matches. Used as a fallback when the LLM skips the category record step.
+    """
+    if not name:
+        return None
+    lowered = name.lower()
+    for keywords, category in _CATEGORY_KEYWORDS:
+        for kw in keywords:
+            if kw in lowered:
+                return category
+    return None
+
+
 # Enrichment hints by category — tells the agent which questions matter most
 CATEGORY_ENRICHMENT_HINTS: dict[str, list[str]] = {
     "Laptops": [

--- a/tests/test_intake_category_inference.py
+++ b/tests/test_intake_category_inference.py
@@ -1,0 +1,70 @@
+"""Unit tests for the rule-based category inference fallback.
+
+This is the safety net when the LLM skips its `record_attribute(category=...)`
+call. It must produce a category from the `CATEGORY_LIST` for any reasonable
+item name.
+"""
+
+from packages.agents.intake.tools import CATEGORY_LIST, infer_category
+
+
+def test_returns_none_for_empty_name() -> None:
+    assert infer_category("") is None
+
+
+def test_returns_none_for_unknown_item() -> None:
+    assert infer_category("a wibbly wobbly thingamajig") is None
+
+
+def test_only_returns_categories_in_canonical_list() -> None:
+    """Whatever we infer must be a valid category the rest of the system knows."""
+    for name in [
+        "Sony WH-1000XM5",
+        "MacBook Pro",
+        "iPad Air",
+        "iPhone 15 Pro",
+        "Nike Air Max trainers",
+        "Casio digital watch",
+        "PlayStation 5",
+    ]:
+        category = infer_category(name)
+        assert category is None or category in CATEGORY_LIST
+
+
+def test_infers_headphones_from_keyword() -> None:
+    assert infer_category("Headphones") == "Headphones"
+    assert infer_category("Wireless headphones") == "Headphones"
+    assert infer_category("Sony WH-1000XM5 headphones") == "Headphones"
+    assert infer_category("Apple AirPods Pro") == "Headphones"
+
+
+def test_infers_laptops() -> None:
+    assert infer_category("MacBook Pro 2021") == "Laptops"
+    assert infer_category("Lenovo ThinkPad X1") == "Laptops"
+    assert infer_category("Dell XPS laptop") == "Laptops"
+
+
+def test_infers_phones() -> None:
+    assert infer_category("iPhone 15 Pro") == "Phones"
+    assert infer_category("Samsung Galaxy S24") == "Phones"
+    assert infer_category("Pixel 8") == "Phones"
+
+
+def test_infers_tablets() -> None:
+    assert infer_category("iPad Air") == "Tablets"
+    assert infer_category("Kindle Paperwhite") == "Tablets"
+
+
+def test_infers_trainers_before_shoes() -> None:
+    """Trainer keywords should win over generic shoe keywords."""
+    assert infer_category("Nike Air Max trainers") == "Trainers"
+
+
+def test_infers_gaming_console() -> None:
+    assert infer_category("Sony PlayStation 5") == "Gaming Consoles"
+    assert infer_category("Nintendo Switch OLED") == "Gaming Consoles"
+
+
+def test_case_insensitive() -> None:
+    assert infer_category("HEADPHONES") == "Headphones"
+    assert infer_category("MaCbOoK") == "Laptops"


### PR DESCRIPTION
# Fix: Three Production Bugs Breaking the Intake → Publish Pipeline

## Overview
This PR addresses three critical bugs observed in the sandbox API logs. These fixes are grouped together as they impact the core listing pipeline and share a common test suite (`test_publisher.py`).

---

## Bug 1: Listing Text Generation (OpenAI 400)

### Issue
The Azure GPT-5 (reasoning-class) model rejects any `temperature` value other than the default. This caused a `BadRequestError: 400` during text generation and comparable validation.

### Resolution
Removed the `temperature` override at both callsites:
*   `packages/agents/intake/tools.py` (`_generate_listing_text`): Removed `temperature=0.3`.
*   `packages/agents/pricing/comparable_filter.py` (Comparable validator): Removed `temperature=0`.

*Internal notes have been added to these files to prevent future re-introduction of these parameters.*

---

## Bug 2: Inventory Creation (eBay 400)

### Issue
The eBay Sell Inventory API returned `"Could not serialize field [condition]"` because the internal map was using legacy Trading API enum values (`GOOD`, `LIKE_NEW`) which are invalid for most modern categories.

### Resolution
Updated `_CONDITION_MAP` to use universal Sell Inventory API aliases:

| Internal Key | Old Value (Broken) | New Value (Correct) |
| :--- | :--- | :--- |
| `new` | `NEW` | `NEW` |
| `like_new` | `LIKE_NEW` | `USED_EXCELLENT` |
| `good` | `GOOD` | `USED_GOOD` |
| `fair` | `GOOD` | `USED_ACCEPTABLE` |
| `poor` | `FOR_PARTS_OR_NOT_WORKING` | `FOR_PARTS_OR_NOT_WORKING` |

*   **Fallbacks:** Updated default `get` calls to `"USED_GOOD"`.
*   **Trading API:** `_CONDITION_TRADING_API_MAP` remains unchanged as numeric IDs are still required for XML payloads.

---

## Bug 3: Intake Agent Category Loop

### Issue
Users were getting stuck in a loop where the agent repeatedly asked for the item category even after it was provided (e.g., "Headphones"). DB inspection showed the LLM was failing to non-deterministically infer the `category` field despite instructions.

### Resolution
Implemented a keyword-based safety net in the logic flow. If `name` is present but `category` is missing, the system attempts an automatic inference before prompting the user.

*   **Implementation:** Added `_CATEGORY_KEYWORDS` and `infer_category(name)` helper in `packages/agents/intake/tools.py`.
*   **Logic:** Integrated `infer_category()` into `packages/agents/intake/graph.py:_plan_next_step` to resolve missing categories before triggering the canned question branch.

---

## Test Changes
*   **Condition Mapping:** Updated `tests/test_publisher.py` to reflect the new eBay Sell Inventory API values.
*   **Category Inference:** Added `tests/test_intake_category_inference.py` with 10 new tests covering:
    *   Keyword precedence (e.g., "trainers" > "shoes").
    *   Case-insensitivity.
    *   Validation against `CATEGORY_LIST`.
    *   Unknown item handling.

---

## Verification Results
*   **Tests:** 39/39 passing on this branch.
*   **Linting:** `ruff` and `mypy` clean.

### Manual Verification Checklist (Post-Deploy)
1. [ ] Run full **Intake → Pricing → Publish** flow on a sandbox item.
2. [ ] Verify logs show no OpenAI `BadRequestError`.
3. [ ] Verify logs show no eBay `condition` serialization error.
4. [ ] Confirm the listing appears live on Sandbox eBay.
5. [ ] Open chat, type *"I want to sell my headphones"*, and ensure the agent moves past the category question immediately.

---

## Out of Scope
*   Category-aware overrides for legacy `LIKE_NEW` values (Media categories).
*   Expansion of the keyword list for `infer_category` beyond major categories.
*   Interaction with Phase 4 Messaging/NLP branches.