### PR TITLE
feat: enable direct API calls via CORS configuration to bypass Next.j…

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from apps.api.routers import auth, ebay, health, images, intake, internal, pages, webhooks
-from packages.config import configure_tracing
+from packages.config import configure_tracing, settings
 
 # Activate LangSmith tracing before any LangGraph graph is compiled
 configure_tracing()
@@ -9,6 +10,17 @@ configure_tracing()
 app = FastAPI(
     title="Multi-Agent Sales Assistant",
     version="0.0.1",
+)
+
+# CORS — let the Vercel frontend call the API directly so we don't rely on
+# the Next.js rewrite proxy (which has its own short upstream timeout).
+_allowed_origins = [o.strip() for o in settings.cors_allowed_origins.split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 # --- ROUTER REGISTRATION ---
 # This tells FastAPI: "When a request comes in for '/health', hand it off to the

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,4 +1,8 @@
-const BASE = "/api";
+// When NEXT_PUBLIC_API_URL is set (production / Vercel), call the backend
+// directly to avoid the Next.js rewrite proxy's upstream timeout.
+// When unset (local dev), fall back to the relative `/api` path which the
+// Next.js rewrite forwards to API_URL (defaulting to http://localhost:8000).
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? "/api";
 
 function token(): string | null {
   if (typeof window === "undefined") return null;

--- a/packages/config.py
+++ b/packages/config.py
@@ -69,6 +69,12 @@ class Settings(BaseSettings):
     ebay_webhook_endpoint: str = ""  # public URL where the webhook will be hosted
     frontend_base_url: str = "http://localhost:3000"  # override in production
 
+    # Comma-separated list of origins allowed to make CORS requests against
+    # the API. Set this to your Vercel domain (and localhost for dev) so the
+    # browser can call the API directly instead of going through the Next.js
+    # rewrite proxy (which has its own short timeout).
+    cors_allowed_origins: str = "http://localhost:3000"
+
     # Browse API credentials — can point at production even while OAuth uses sandbox
     # (sandbox Browse index is sparse; production gives real comparable data)
     ebay_browse_env: str = "production"


### PR DESCRIPTION
## Bypass Vercel rewrite proxy for direct browser → API calls                                                                                                                               
                                                                                                                                                                                              
  Fixes "Failed to fetch" errors in the chat UI on long-running intake messages.                                                                                                              
                                                                                                                                                                                              
  ### What was happening                                                                                                                                                                      
                                                                                                                                                                                              
  The frontend was calling the backend through a Next.js rewrite (`/api/:path* → ${API_URL}/:path*` in `next.config.ts`). Vercel handles rewrites with an edge proxy that has a fixed upstream
   timeout (~30-60s depending on plan).
                                                                                                                                                                                              
  When the LangGraph intake loop chained multiple Azure GPT-5 calls, the cumulative response time exceeded that timeout. Vercel killed the connection from the browser's side; the API still  
  completed the work and logged 200, but the browser saw `Failed to fetch`.
                                                                                                                                                                                              
  ### Fix                                                                                                                                                                                     
   
  Have the browser call `https://devopslearn.store` directly. Only nginx's `proxy_read_timeout 300s` is in the path, which is plenty for any realistic intake run.                            
                                                            
  ### Backend changes                                                                                                                                                                         
                                                            
  - **`packages/config.py`** — new `cors_allowed_origins: str` setting (comma-separated). Default is `http://localhost:3000` for local dev.                                                   
  - **`apps/api/main.py`** — added FastAPI `CORSMiddleware` parameterised by that setting. Allows credentials, all methods, all headers.
                                                                                                                                                                                              
  ### Frontend changes                                      
                                                                                                                                                                                              
  - **`apps/web/lib/api.ts`** — `BASE` is now `process.env.NEXT_PUBLIC_API_URL ?? "/api"`. When the env var is set (production), the browser calls the backend directly. When unset (local    
  dev), it falls back to the existing `/api` rewrite so `make up` keeps working without changes.
                                                                                                                                                                                              
  ### Deploy steps (post-merge)                                                                                                                                                               
   
  **Server (`13.43.196.162`):**                                                                                                                                                               
                                                            
  ```bash                                                                                                                                                                                     
  echo "CORS_ALLOWED_ORIGINS=https://multi-agentic-sales-representative.vercel.app,http://localhost:3000" >> ~/multi-agentic-sales-representative-system/.env
  cd ~/multi-agentic-sales-representative-system && git pull && docker compose down && docker compose up -d --build                                                                           
                                                                                                                                                                                              
  Vercel:                                                                                                                                                                                     
                                                                                                                                                                                              
  1. Project → Settings → Environment Variables             
  2. Add NEXT_PUBLIC_API_URL=https://devopslearn.store (Production + Preview + Development)
  3. Redeploy                                                                                                                                                                                 
   
  Verification                                                                                                                                                                                
                                                            
  After deploy, in browser dev tools → Network tab:                                                                                                                                           
  - Intake / pricing / status requests should target https://devopslearn.store/..., not /api/... on the Vercel domain
  - A long intake message (e.g. detailed product description that triggers multi-iteration LangGraph) should complete instead of erroring with "Failed to fetch"                              
  - The OPTIONS preflight on the first cross-origin request should return 200 with access-control-allow-origin matching the Vercel host                         
                                                                                                                                                                                              
  Tests                                                                                                                                                                                       
                                                                                                                                                                                              
  - 39/39 existing tests still pass                                                                                                                                                           
  - ruff + mypy clean                                       
  - No new tests added — CORS middleware is FastAPI-stdlib and the BASE-URL change is a one-line config swap; both are end-to-end concerns better covered by the manual verification above    
                                                                                                                                                                                              
  Risks
                                                                                                                                                                                              
  - If CORS_ALLOWED_ORIGINS is missing from the server .env after deploy, the API defaults to http://localhost:3000 only and the Vercel browser will get blocked. Verifying the env var is set
   is part of the deploy steps above.
  - The Next.js rewrite is left in place as a local-dev fallback. If we later remove /api from next.config.ts, local dev would also need NEXT_PUBLIC_API_URL=http://localhost:8000 set in     
  apps/web/.env.local.                                                                                                                                                                        
   
  Out of scope                                                                                                                                                                                
                                                            
  - Tuning Vercel function timeout or upgrading the plan — irrelevant once we bypass the proxy                                                                                                
  - The _generate_listing_text long-run itself; a follow-up could stream tokens or shorten the prompt, but it's not blocking once the proxy isn't in the way