### PR TITLE
feat: implement robust item specific extraction and default value han…

### DIFF
--- a/packages/platform_adapters/ebay/sell.py
+++ b/packages/platform_adapters/ebay/sell.py
@@ -637,27 +637,138 @@ class PublishResult:
     listing_url: str
 
 
+# Common colours we can detect in free text. Order matters when overlap is
+# possible — multi-word phrases first so "rose gold" wins over "gold".
+_COLOUR_PATTERNS = (
+    "rose gold",
+    "smoky pink",
+    "midnight black",
+    "matte black",
+    "matte white",
+    "space grey",
+    "space gray",
+    "silver",
+    "gold",
+    "black",
+    "white",
+    "red",
+    "blue",
+    "green",
+    "yellow",
+    "pink",
+    "purple",
+    "grey",
+    "gray",
+    "navy",
+    "beige",
+    "tan",
+    "brown",
+    "orange",
+    "ivory",
+    "cream",
+)
+
+
+def _detect_colour(text: str) -> str | None:
+    lowered = text.lower()
+    for colour in _COLOUR_PATTERNS:
+        # Word-boundary match so e.g. "tan" doesn't match inside "standard".
+        if re.search(rf"\b{re.escape(colour)}\b", lowered):
+            return colour.title()
+    return None
+
+
+def _detect_connectivity(text: str) -> str | None:
+    """Best-effort connectivity detection (Wireless / Bluetooth / Wired)."""
+    lowered = text.lower()
+    if "true wireless" in lowered:
+        return "True Wireless"
+    if "wireless" in lowered or "bluetooth" in lowered:
+        return "Wireless"
+    if "wired" in lowered or "3.5mm" in lowered:
+        return "Wired"
+    return None
+
+
+def _detect_model(item: Item) -> str | None:
+    """Model = item name with the brand stripped off, if present.
+
+    e.g. brand='Sony', name='Sony WH-1000XM5 Wireless Headphones'
+        → 'WH-1000XM5 Wireless Headphones'.
+    """
+    name = (item.name or "").strip()
+    if not name:
+        return None
+    brand = (item.brand or "").strip()
+    if brand and name.lower().startswith(brand.lower()):
+        candidate = name[len(brand) :].strip(" -:")
+        return candidate or None
+    return name
+
+
+# Category → safe default 'Type' value when we can't extract one from the
+# item text. eBay accepts free-text values for Type in most categories.
+_CATEGORY_TYPE_DEFAULT = {
+    "Headphones": "Other",
+    "Speakers": "Other",
+    "Laptops": "Notebook/Laptop",
+    "Phones": "Smartphone",
+    "Tablets": "Other",
+    "Watches": "Wristwatch",
+    "Cameras": "Other",
+    "Trainers": "Trainer",
+    "Shoes": "Other",
+    "Clothing": "Other",
+    "Headphones Type": "Other",
+}
+
+
 def _build_item_specifics(item: Item) -> dict[str, str]:
-    """Extract key item specifics from an Item's fields and name for Trading API."""
+    """Extract key item specifics from an Item's fields and name for Trading API.
+
+    eBay categories enforce a set of required ItemSpecifics (e.g. Headphones
+    requires Brand, Model, Type, Connectivity, Colour). Missing any of them
+    causes AddFixedPriceItem to 400. We extract what we can from the
+    name/description, then fill the rest with safe fallbacks so the listing
+    can publish even when the intake agent didn't capture every field.
+    """
     specifics: dict[str, str] = {}
-
-    if item.brand:
-        specifics["Brand"] = item.brand
-
-    # Parse common specs from item name/description
     text = f"{item.name or ''} {item.description or ''}"
 
-    # Screen size: "15-Inch", "15.6 inch", "13\"", etc.
+    # ── Brand ───────────────────────────────────────────────────────────────
+    if item.brand:
+        specifics["Brand"] = item.brand
+    else:
+        specifics["Brand"] = "Unbranded"
+
+    # ── Model ───────────────────────────────────────────────────────────────
+    model = _detect_model(item)
+    if model:
+        specifics["Model"] = model[:65]  # eBay caps at 65 chars
+
+    # ── Colour / Connectivity / Type — required for several categories ──────
+    colour = _detect_colour(text)
+    specifics["Colour"] = colour or "Multicolour"
+
+    connectivity = _detect_connectivity(text)
+    if connectivity:
+        specifics["Connectivity"] = connectivity
+    elif (item.category or "").strip() in {"Headphones", "Speakers"}:
+        specifics["Connectivity"] = "Wireless"
+
+    type_default = _CATEGORY_TYPE_DEFAULT.get((item.category or "").strip())
+    if type_default:
+        specifics["Type"] = type_default
+
+    # ── Laptop / phone specs (legacy regex extraction) ──────────────────────
     m = re.search(r'(\d+(?:\.\d+)?)\s*["\-]?(?:inch|in\b)', text, re.IGNORECASE)
     if m:
         specifics["Screen Size"] = f"{m.group(1)} in"
 
-    # Apple Silicon: M1/M2/M3/M4 [Pro/Max/Ultra]
     m = re.search(r"\b(M[1-4](?:\s*(?:Pro|Max|Ultra))?)\b", text, re.IGNORECASE)
     if m:
         specifics["Processor"] = f"Apple {m.group(1).strip()}"
     else:
-        # Intel/AMD processor
         m = re.search(
             r"\b(Core\s+i[3579][-\s]\d+\w*|Ryzen\s+\d+\s*\d+\w*|Celeron\s+\w+)\b",
             text,
@@ -666,17 +777,15 @@ def _build_item_specifics(item: Item) -> dict[str, str]:
         if m:
             specifics["Processor"] = m.group(1)
 
-    # RAM: "16GB RAM", "16 GB"
     m = re.search(r"(\d+)\s*GB\s*RAM", text, re.IGNORECASE)
     if m:
         specifics["RAM Size"] = f"{m.group(1)} GB"
 
-    # Storage: "256GB SSD", "512GB SSD", "1TB SSD"
     m = re.search(r"(\d+)\s*(GB|TB)\s*SSD", text, re.IGNORECASE)
     if m:
         specifics["SSD Capacity"] = f"{m.group(1)} {m.group(2).upper()}"
 
-    # Any extra attributes the intake agent stored
+    # ── Any extra attributes the intake agent stored win over defaults ──────
     attrs = item.attributes or {}
     for key, val in attrs.items():
         if key not in {"brand"} and val:

--- a/tests/test_item_specifics.py
+++ b/tests/test_item_specifics.py
@@ -1,0 +1,140 @@
+"""Unit tests for the Trading API ItemSpecifics builder.
+
+Covers the colour / connectivity / model / type detectors that fill in the
+required eBay specifics so AddFixedPriceItem doesn't 400 on missing values
+when the intake agent didn't capture them.
+"""
+
+import uuid
+from unittest.mock import MagicMock
+
+from packages.db.models import Item, ItemCondition, ItemStatus
+from packages.platform_adapters.ebay.sell import (
+    _build_item_specifics,
+    _detect_colour,
+    _detect_connectivity,
+    _detect_model,
+)
+
+
+def _item(**overrides) -> Item:
+    defaults = {
+        "id": uuid.uuid4(),
+        "seller_id": uuid.uuid4(),
+        "name": "Sony WH-1000XM5 Wireless Headphones",
+        "brand": "Sony",
+        "category": "Headphones",
+        "subcategory": None,
+        "condition": ItemCondition.good,
+        "description": "Smoky pink, lightly used. Includes case.",
+        "attributes": None,
+        "status": ItemStatus.priced,
+    }
+    defaults.update(overrides)
+    item = MagicMock(spec=Item)
+    for k, v in defaults.items():
+        setattr(item, k, v)
+    return item
+
+
+# ── Colour ─────────────────────────────────────────────────────────────────
+
+
+def test_detect_colour_basic() -> None:
+    assert _detect_colour("smoky pink") == "Smoky Pink"
+    assert _detect_colour("matte black headphones") == "Matte Black"
+    assert _detect_colour("rose gold finish") == "Rose Gold"
+
+
+def test_detect_colour_falls_back_to_single_word() -> None:
+    # When no multi-word phrase matches, single-word colours still match.
+    assert _detect_colour("a beautiful red shoe") == "Red"
+
+
+def test_detect_colour_returns_none_when_absent() -> None:
+    assert _detect_colour("just a generic description") is None
+
+
+# ── Connectivity ───────────────────────────────────────────────────────────
+
+
+def test_detect_connectivity_wireless() -> None:
+    assert _detect_connectivity("Wireless Bluetooth headphones") == "Wireless"
+    assert _detect_connectivity("Bluetooth speaker") == "Wireless"
+
+
+def test_detect_connectivity_true_wireless_takes_priority() -> None:
+    assert _detect_connectivity("True wireless earbuds with bluetooth") == "True Wireless"
+
+
+def test_detect_connectivity_wired() -> None:
+    assert _detect_connectivity("Wired in-ear headphones with 3.5mm jack") == "Wired"
+
+
+def test_detect_connectivity_unknown() -> None:
+    assert _detect_connectivity("Just a generic description") is None
+
+
+# ── Model ──────────────────────────────────────────────────────────────────
+
+
+def test_detect_model_strips_brand_prefix() -> None:
+    item = _item(brand="Sony", name="Sony WH-1000XM5 Wireless Headphones")
+    assert _detect_model(item) == "WH-1000XM5 Wireless Headphones"
+
+
+def test_detect_model_returns_full_name_when_brand_missing() -> None:
+    item = _item(brand=None, name="MacBook Pro 14-inch")
+    assert _detect_model(item) == "MacBook Pro 14-inch"
+
+
+def test_detect_model_returns_none_when_name_empty() -> None:
+    item = _item(name="")
+    assert _detect_model(item) is None
+
+
+# ── _build_item_specifics integration ──────────────────────────────────────
+
+
+def test_headphones_get_all_required_fields() -> None:
+    item = _item()
+    specifics = _build_item_specifics(item)
+    # The four eBay-required Headphones fields must all be present
+    for required in ("Brand", "Model", "Colour", "Connectivity", "Type"):
+        assert required in specifics, f"missing required field {required}"
+    assert specifics["Brand"] == "Sony"
+    assert "WH-1000XM5" in specifics["Model"]
+    assert specifics["Colour"] == "Smoky Pink"
+    assert specifics["Connectivity"] == "Wireless"
+
+
+def test_headphones_default_connectivity_when_unstated() -> None:
+    item = _item(name="Generic Headphones", description="No connectivity info")
+    specifics = _build_item_specifics(item)
+    # Defaults to Wireless for headphones/speakers since we have to send something
+    assert specifics["Connectivity"] == "Wireless"
+
+
+def test_unbranded_brand_fallback() -> None:
+    item = _item(brand=None)
+    specifics = _build_item_specifics(item)
+    assert specifics["Brand"] == "Unbranded"
+
+
+def test_colour_falls_back_to_multicolour_when_undetectable() -> None:
+    item = _item(name="Headphones", description="Standard finish")
+    specifics = _build_item_specifics(item)
+    assert specifics["Colour"] == "Multicolour"
+
+
+def test_model_capped_at_65_chars() -> None:
+    long_name = "Brand X" + " AAAA" * 30
+    item = _item(brand="Brand X", name=long_name)
+    specifics = _build_item_specifics(item)
+    assert len(specifics["Model"]) <= 65
+
+
+def test_attributes_override_defaults() -> None:
+    item = _item(attributes={"colour": "Custom Teal"})
+    specifics = _build_item_specifics(item)
+    assert specifics["Colour"] == "Custom Teal"


### PR DESCRIPTION
# Fill Required eBay ItemSpecifics for Headphones/Electronics

## Overview
This PR implements a **stopgap measure** to resolve `400 Bad Request` errors caused by missing required eBay `ItemSpecifics`. It replaces hard failures with best-effort attribute detection and safe defaults, ensuring a "green path" for the listing pipeline. 

A future PR will replace these defaults with a feedback loop that routes back to Agent 1 to request missing values directly from the seller.

---

## What was failing
The Trading API `AddFixedPriceItem` was failing for the Headphones category (and others) with the following errors:
*   `The item specific Type is missing.`
*   `The item specific Connectivity is missing.`
*   `The item specific Colour is missing.`
*   `The item specific Model is missing.`

While `Brand` was partially captured, the intake agent's current schema doesn't account for these secondary mandatory fields, and the publisher's extraction logic was previously limited to laptop-specific specifications.

---

## Technical Changes: `_build_item_specifics`

### 1. Detection Helpers
Added three new helper methods to extract values from existing item data:
*   **`_detect_colour(text)`**: Performs word-boundary matches against a common color list. Multi-word phrases (e.g., "Rose Gold") take precedence over single words (e.g., "Gold").
*   **`_detect_connectivity(text)`**: Uses priority-based matching: `True Wireless` > `Wireless` > `Wired`.
*   **`_detect_model(item)`**: Strips the brand prefix from the item name (e.g., `brand="Sony", name="Sony WH-1000XM5"` becomes `"WH-1000XM5"`) to avoid redundant eBay titles.

### 2. Mandatory Field Logic
`_build_item_specifics` now ensures the following fields are always emitted for applicable categories:

| Field | Source | Fallback |
| :--- | :--- | :--- |
| **Brand** | `item.brand` | `"Unbranded"` |
| **Model** | `_detect_model(item)` | Omitted |
| **Colour** | `_detect_colour(name + description)` | `"Multicolour"` |
| **Connectivity** | `_detect_connectivity(name + desc)` | `"Wireless"` (Headphones/Speakers) |
| **Type** | `_CATEGORY_TYPE_DEFAULT[item.category]` | Omitted |

*Note: Existing regexes for Laptops/Phones (RAM, SSD, Processor) remain active. Any value manually set in `item.attributes` will override these automated defaults.*

---

## Test Coverage
**16 new tests in `tests/test_item_specifics.py` covering:**
*   **Color Matching:** Multi-word vs. single word and `None` handling.
*   **Boundary Regressions:** Confirmed "tan" does not match "standard".
*   **Connectivity Priority:** Verified `True Wireless` correctly beats `Wireless`.
*   **Model Logic:** Brand stripping, 65-character truncation, and empty name handling.
*   **Integration:** Verified `_build_item_specifics` emits all 5 required fields for the Headphones category.

**Total Stats:** 55/55 passing; `ruff` and `mypy` clean.

---

## Known Limitations (Stopgap Context)
*   **Guesses:** Defaults like `Multicolour` or `Wireless` are educated guesses. If the intake agent didn't capture the real value, the listing will go live with these defaults.
*   **Strict Enums:** If an eBay category requires a strict Enum value for `Type` (e.g., `Earbud`) and rejects our generic fallback, the 400 error may still occur. This will be resolved by the upcoming feedback loop.

---

## Next Steps (Feedback Loop Architecture)
The permanent fix will involve:
1. Publisher catching the 400 and parsing missing fields into `item.required_specifics`.
2. Setting `item.status = needs_more_info`.
3. Agent 1 detecting this status and asking the seller for the specific missing values.
4. Re-publishing only once the required data is captured.