### PR TITLE
Implement a reactive workflow to recover from eBay item-specific erro…

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_needs_specifics_status_and_required_specifics.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_needs_specifics_status_and_required_specifics.py
@@ -1,0 +1,49 @@
+"""add needs_specifics status and required_specifics column
+
+Revision ID: a1b2c3d4e5f6
+Revises: dd06bb949617
+Create Date: 2026-05-07 16:55:00.000000
+
+Adds a `needs_specifics` value to the `item_status` enum and a
+`required_specifics` JSONB column on `items` so the publisher can record
+the eBay item-specific names a seller still owes us before the listing
+can publish.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "dd06bb949617"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Postgres requires ALTER TYPE ... ADD VALUE outside a transaction block,
+    # but alembic wraps each migration in one. COMMIT first, add the value,
+    # then reopen the implicit transaction.
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE item_status ADD VALUE IF NOT EXISTS 'needs_specifics'")
+
+    op.add_column(
+        "items",
+        sa.Column(
+            "required_specifics",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("items", "required_specifics")
+    # Removing an enum value in Postgres requires recreating the type. We
+    # leave the value in place on downgrade — it's inert without code that
+    # writes it. If a clean removal is needed, do it via a manual
+    # data-migration script.

--- a/apps/api/routers/intake.py
+++ b/apps/api/routers/intake.py
@@ -127,9 +127,24 @@ async def get_listing_status(
     """
     Return the listing status for an item once publishing has started.
 
-    Returns null while the item is still being priced.
-    Once the publisher agent runs, returns status + eBay URL.
+    Returns null while the item is still being priced. When the publisher
+    has parked the item awaiting more eBay item-specifics from the seller,
+    surfaces `status="needs_specifics"` plus `required_specifics` so the
+    frontend can resume the chat.
     """
+    # Item-level state takes precedence over listing-level when the publisher
+    # parked it — the listing row stays at "publishing" while specifics are
+    # outstanding so we don't lose the in-flight publish attempt.
+    item = await session.scalar(select(Item).where(Item.id == item_id, Item.seller_id == seller.id))
+    if item is not None and item.status == "needs_specifics":
+        return {
+            "status": "needs_specifics",
+            "required_specifics": list(item.required_specifics or []),
+            "url": None,
+            "external_id": None,
+            "posted_price": (float(item.recommended_price) if item.recommended_price else None),
+        }
+
     listing = await session.scalar(
         select(Listing).where(
             Listing.item_id == item_id,

--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -101,7 +101,16 @@ Follow this exact sequence:
 - If the seller says something like "looks good" or "that's fine" after you \
   present the generated listing, proceed to request_image.
 - If the seller provides all details upfront in one message, you can skip \
-  enrichment questions and go straight to generate_listing.\
+  enrichment questions and go straight to generate_listing.
+
+═══ FILLING MISSING eBay SPECIFICS ═══
+If the conversation is in 'needs_specifics' mode (you'll see a system note \
+listing the missing fields), your ONLY job is to ask the seller for those \
+specifics one at a time and record each answer with record_item_specific. \
+Do NOT call record_attribute for these — they are platform-specific values, \
+not core item fields. Do NOT call generate_listing or mark_intake_complete \
+in this mode; the system handles re-publishing automatically once the list \
+is empty.\
 """
 
 
@@ -165,6 +174,31 @@ async def _plan_next_step(
             False,
         )
 
+    # ── needs_specifics recovery loop ──────────────────────────────────────
+    # If the publisher parked this item awaiting more info, drive the
+    # conversation toward filling those fields and trigger a re-publish
+    # once the list is empty. This precedes the standard missing-field
+    # check because needs_specifics implies the basics are already in place.
+    if item.status == ItemStatus.needs_specifics:
+        if item.required_specifics:
+            next_field = item.required_specifics[0]
+            return (
+                f"To finish publishing on eBay I just need the {next_field}"
+                " of your item — could you tell me?",
+                False,
+                False,
+            )
+        # All specifics gathered — nothing left in the list. Drop back to
+        # `priced` so the publisher accepts it and queue a publish-only run.
+        item.status = ItemStatus.priced
+        await session.flush()
+        await _enqueue_publish_only(item.seller_id, item.id)
+        return (
+            "Thanks — I have everything I need. Re-publishing your listing now.",
+            False,
+            True,
+        )
+
     # Check for missing fields
     missing = _missing_fields(item)
     if missing:
@@ -220,6 +254,34 @@ async def _plan_next_step(
     return "Great — I have everything I need to prepare your listing!", False, True
 
 
+# Holds references to in-flight dev-mode publish_only tasks so the event
+# loop's GC doesn't collect them before they finish.
+_BACKGROUND_TASKS: set[Any] = set()
+
+
+async def _enqueue_publish_only(seller_id: uuid.UUID, item_id: uuid.UUID) -> None:
+    """Trigger a publisher-only re-run after intake clears required_specifics.
+
+    Mirrors the SQS-or-BackgroundTasks pattern used in the intake router so
+    local dev keeps working without SQS configured.
+    """
+    from packages.config import settings
+
+    if settings.sqs_queue_url:
+        from packages.bus.sqs import enqueue
+
+        enqueue("publish_only", seller_id=str(seller_id), item_id=str(item_id))
+        return
+
+    import asyncio
+
+    from packages.agents.pipeline import run_publisher_only
+
+    task = asyncio.create_task(run_publisher_only(seller_id, item_id))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
 @traceable(name="intake_node", run_type="chain")
 async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, Any]:
     """
@@ -243,6 +305,14 @@ async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, A
         item = await session.scalar(select(Item).where(Item.id == item_id))
         if item and item.category:
             system_content += _enrichment_context(item.category)
+        if item and item.status == ItemStatus.needs_specifics and item.required_specifics:
+            specifics = ", ".join(item.required_specifics)
+            system_content += (
+                f"\n\nNOTE: needs_specifics mode is active. "
+                f"Outstanding fields: {specifics}. "
+                "Ask the seller about exactly one of these per turn and record "
+                "the answer with record_item_specific."
+            )
 
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": system_content},

--- a/packages/agents/intake/tools.py
+++ b/packages/agents/intake/tools.py
@@ -314,6 +314,33 @@ TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
+            "name": "record_item_specific",
+            "description": (
+                "Record an eBay item-specific value the seller has supplied. Use ONLY "
+                "when the item is in `needs_specifics` state and the seller has just "
+                "answered a question about a required eBay field (e.g. 'Type', "
+                "'Connectivity', 'Colour', 'Model'). Do NOT use this for core fields "
+                "like brand or condition — those go through record_attribute."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The eBay item-specific name (e.g. 'Type').",
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The seller's answer.",
+                    },
+                },
+                "required": ["name", "value"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "mark_intake_complete",
             "description": (
                 "Mark intake as complete once you have: (1) recorded all attributes, "
@@ -493,6 +520,27 @@ async def execute_tool(
 
         await session.flush()
         return f"Saved {field} = {value!r}", item.id
+
+    if tool_name == "record_item_specific":
+        name = tool_input.get("name")
+        value = tool_input.get("value")
+        if not name or value is None:
+            return "Error: record_item_specific requires both 'name' and 'value'", item_id
+
+        item = await _get_or_create_item(seller_id, item_id, session)
+        # Persist the specific into attributes (used downstream by the publisher)
+        attrs = dict(item.attributes or {})
+        attrs[str(name)] = str(value)
+        item.attributes = attrs
+
+        # Pop the name off the still-needed list. Idempotent — repeated
+        # calls just no-op once the name is gone.
+        if item.required_specifics:
+            remaining = [n for n in item.required_specifics if n != name]
+            item.required_specifics = remaining or None
+
+        await session.flush()
+        return f"Saved item-specific {name} = {value!r}", item.id
 
     if tool_name == "generate_listing":
         raw_title = tool_input["raw_title"]

--- a/packages/agents/pipeline.py
+++ b/packages/agents/pipeline.py
@@ -131,3 +131,34 @@ async def run_pipeline(seller_id: uuid.UUID, item_id: uuid.UUID) -> None:
                 "run_name": f"listing_pipeline_{item_id}",
             },
         )
+
+
+@traceable(name="publish_only", run_type="chain")
+async def run_publisher_only(seller_id: uuid.UUID, item_id: uuid.UUID) -> None:
+    """Re-run the publisher without re-pricing.
+
+    Triggered after the intake agent clears `item.required_specifics` —
+    pricing already ran on the original pipeline pass, so we don't redo
+    it (saves an LLM round-trip on the comparable validator and avoids
+    flapping the recommended price).
+    """
+    from packages.db.session import SessionLocal
+    from packages.schemas.agents import PricingResult
+
+    async with SessionLocal() as session:
+        item = await session.scalar(select(Item).where(Item.id == item_id))
+        if item is None:
+            return
+
+        pricing = PricingResult(
+            item_id=item_id,
+            recommended_price=float(item.recommended_price or 0),
+            confidence_score=float(item.confidence_score or 0),
+            min_acceptable_price=float(item.min_acceptable_price or 0),
+        )
+        await run_publisher(
+            item_id=item_id,
+            seller_id=seller_id,
+            pricing=pricing,
+            session=session,
+        )

--- a/packages/agents/publisher/agent.py
+++ b/packages/agents/publisher/agent.py
@@ -17,6 +17,7 @@ On eBay 4xx/5xx errors, sets Item.status = 'error' and records the failure.
 """
 
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 
@@ -40,6 +41,29 @@ from packages.platform_adapters.ebay.sell import (
 from packages.schemas.agents import ListingResult, PricingResult
 
 logger = logging.getLogger(__name__)
+
+
+# eBay's error string for missing item-specifics is consistent:
+#   "The item specific Type is missing. Add Type to this listing, ..."
+# We pull the names out so the intake agent can ask the seller for them.
+_MISSING_SPECIFIC_RE = re.compile(
+    r"item specific ([A-Za-z][A-Za-z0-9 &/\-]*?) is missing",
+    re.IGNORECASE,
+)
+
+
+def _parse_missing_specifics(err_text: str) -> list[str]:
+    """Extract eBay item-specific names from a Trading API error string.
+
+    Returns names in first-seen order with duplicates removed. An empty
+    list means the error wasn't a missing-specifics rejection.
+    """
+    seen: dict[str, None] = {}
+    for match in _MISSING_SPECIFIC_RE.finditer(err_text):
+        name = match.group(1).strip()
+        if name:
+            seen.setdefault(name, None)
+    return list(seen.keys())
 
 
 @traceable(name="publisher_agent", run_type="chain")
@@ -187,9 +211,34 @@ async def run(
         )
 
     except Exception as exc:
+        # Reactive recovery path: if eBay rejected for missing item-specifics,
+        # park the item in needs_specifics and let the intake agent ask the
+        # seller. Anything we can't parse stays a hard error.
+        missing = _parse_missing_specifics(str(exc))
+        if missing:
+            item.required_specifics = missing
+            item.status = ItemStatus.needs_specifics
+            # Keep the listing row open at "publishing" — we'll re-attempt
+            # once the seller has filled in the gaps. close_reason cleared
+            # so the UI doesn't show a stale failure message.
+            listing.status = ListingStatus.publishing
+            listing.close_reason = None
+            await session.commit()
+
+            logger.info(
+                "[Agent 3 — Publisher] item %s needs specifics: %s",
+                item_id,
+                missing,
+            )
+            return ListingResult(
+                item_id=item_id,
+                platform="ebay",
+                status="needs_specifics",
+            )
+
         logger.exception("[Agent 3 — Publisher] Failed to publish item %s: %s", item_id, exc)
 
-        # Mark as error state
+        # Hard error path
         listing.status = ListingStatus.error
         listing.close_reason = str(exc)[:255]
         item.status = ItemStatus.error

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -40,6 +40,7 @@ class ItemStatus(enum.StrEnum):
     intake_complete = "intake_complete"  # Ready for pricing
     priced = "priced"  # Price assigned
     publishing = "publishing"  # Being pushed to marketplace
+    needs_specifics = "needs_specifics"  # eBay rejected — seller must supply more item specifics
     live = "live"  # Visible for sale
     sold = "sold"  # Completed sale
     removed = "removed"  # Withdrawn or deleted
@@ -163,6 +164,12 @@ class Item(Base):
     price_low: Mapped[float | None] = mapped_column(Numeric(12, 2))  # CI lower bound
     price_high: Mapped[float | None] = mapped_column(Numeric(12, 2))  # CI upper bound
     pricing_comparables: Mapped[list[Any] | None] = mapped_column(JSONB)  # raw comparable listings
+
+    # eBay item-specific names that the seller still owes us before the
+    # listing can publish. Populated by the publisher when AddFixedPriceItem
+    # rejects with "item specific X is missing"; cleared one-by-one by
+    # intake as the seller answers each one.
+    required_specifics: Mapped[list[str] | None] = mapped_column(JSONB)
 
     # Workflow state machine
     status: Mapped[ItemStatus] = mapped_column(

--- a/publisher-agent-v2-implementation-plan.md
+++ b/publisher-agent-v2-implementation-plan.md
@@ -1,0 +1,350 @@
+# Implementation Plan — Publisher v2: Reactive Specifics Recovery
+
+When eBay rejects a listing for missing item-specifics (e.g. `Type`,
+`Connectivity`, `Colour`, `Model` for Headphones), the publisher today fails
+with `status=error` and the pipeline halts. v2 makes this recoverable: the
+publisher parses the missing fields out of the eBay error, hands the item
+back to Agent 1 to ask the seller, and re-runs the publisher only once the
+seller has answered.
+
+## Design
+
+### Reactive vs proactive — chosen: reactive
+
+We **do not** call eBay's Taxonomy API to enumerate required aspects ahead
+of time. Reasons:
+
+- eBay's error message is the source of truth. Whatever it says is missing
+  is exactly what's missing — no cache drift, no sandbox/prod schema diff.
+- Even with proactive Taxonomy calls we'd still need error parsing for
+  other rejections (invalid `Type` enum, condition/category mismatch,
+  price < £0.99). Reactive subsumes the work.
+- Latency: reactive only pays the round-trip when the seller actually has
+  gaps. The happy path costs nothing extra.
+
+A future enhancement can layer Taxonomy on top of this for "preview missing
+fields without attempting to publish" UX, but it's not required for
+correctness.
+
+### State transitions
+
+```
+intake_complete → priced → publishing ─────────► live
+                                  │
+                                  └─► needs_specifics ─► (intake collects) ─► priced ─► publishing ─► live
+```
+
+The publisher writes `needs_specifics` instead of `error` when the failure
+is parseable as missing item-specifics. Anything else still goes to
+`error` as before.
+
+When the seller satisfies all `required_specifics`, the intake triggers a
+**publisher-only** task — pricing has already run and shouldn't be redone.
+
+## Schema
+
+### [MODIFY] `packages/db/models.py`
+
+```python
+class ItemStatus(enum.StrEnum):
+    pending = "pending"
+    intake_in_progress = "intake_in_progress"
+    intake_complete = "intake_complete"
+    priced = "priced"
+    publishing = "publishing"
+    needs_specifics = "needs_specifics"   # NEW
+    live = "live"
+    sold = "sold"
+    removed = "removed"
+    error = "error"
+```
+
+```python
+class Item(Base):
+    ...
+    # eBay item-specific names that the seller still needs to provide before
+    # a listing can publish (e.g. ["Type", "Connectivity", "Colour"]).
+    # Populated by the publisher when AddFixedPriceItem rejects the listing
+    # for missing aspects; cleared by intake as the seller answers each one.
+    required_specifics: Mapped[list[str] | None] = mapped_column(JSONB)
+```
+
+### Migration
+
+Single alembic revision: adds `needs_specifics` to `item_status` enum +
+adds `required_specifics` JSONB column. Down-migration drops the column;
+removing an enum value Postgres-side requires a recreate dance, so the
+down migration documents it but does not perform the destructive enum
+edit (that's standard alembic practice).
+
+## Publisher (Agent 3) — error parser + status branch
+
+### [MODIFY] `packages/agents/publisher/agent.py`
+
+Catch `RuntimeError` raised from `publish_offer` (and similar from
+`create_inventory_item`), parse missing-specific names, and persist them
+instead of erroring:
+
+```python
+import re
+
+_MISSING_SPECIFIC_RE = re.compile(
+    r"item specific (\w[\w &-]*?) is missing", re.IGNORECASE
+)
+
+
+def _parse_missing_specifics(err_text: str) -> list[str]:
+    """Extract eBay item-specific names from a Trading API error string.
+
+    Example input:
+      'Trading API AddFixedPriceItem failed: The item specific Type is missing.
+       Add Type ... ; The item specific Connectivity is missing. ...'
+    Returns deduplicated, order-preserved names: ['Type', 'Connectivity', ...]
+    """
+    seen: dict[str, None] = {}
+    for match in _MISSING_SPECIFIC_RE.finditer(err_text):
+        name = match.group(1).strip()
+        seen.setdefault(name, None)
+    return list(seen.keys())
+
+
+# In run() — replace the catch-all error path with:
+except Exception as exc:
+    missing = _parse_missing_specifics(str(exc))
+    if missing:
+        item.required_specifics = missing
+        item.status = ItemStatus.needs_specifics
+        listing.status = ListingStatus.publishing  # keep open; we'll retry
+        listing.close_reason = None
+        await session.commit()
+
+        logger.info(
+            "[Agent 3 — Publisher] needs_specifics for %s: %s",
+            item_id, missing,
+        )
+        return ListingResult(
+            item_id=item_id, platform="ebay", status="needs_specifics",
+        )
+
+    # Anything we can't parse as a missing-specific failure stays an error
+    logger.exception("[Agent 3 — Publisher] Failed to publish item %s", item_id)
+    listing.status = ListingStatus.error
+    listing.close_reason = str(exc)[:255]
+    item.status = ItemStatus.error
+    await session.commit()
+    return ListingResult(item_id=item_id, platform="ebay", status="error")
+```
+
+### Schema additions
+
+`ListingResult.status` already accepts arbitrary strings (`Literal["ebay"]`
+constrains `platform`, not `status`). No schema change there.
+
+## Intake (Agent 1) — gather + clear specifics, trigger republish
+
+### [MODIFY] `packages/agents/intake/tools.py`
+
+Add a single new tool `record_item_specific(name, value)` that writes to
+`item.attributes` and removes `name` from `item.required_specifics`.
+Keeping it separate from `record_attribute` (instead of relaxing the
+existing tool's enum) keeps the LLM honest about what it's recording —
+core fields stay validated, extras stay opt-in.
+
+```python
+{
+  "name": "record_item_specific",
+  "description": (
+    "Record a piece of eBay-required item-specific information the seller "
+    "has provided (e.g. headphone Type, Connectivity, Colour, Model). Use "
+    "ONLY for items in needs_specifics state. Use record_attribute for "
+    "core fields like brand or condition."
+  ),
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "name":  {"type": "string", "description": "The eBay item-specific name (e.g. 'Type')."},
+      "value": {"type": "string", "description": "The seller's answer."},
+    },
+    "required": ["name", "value"],
+  },
+}
+```
+
+`execute_tool` adds a branch:
+
+```python
+if tool_name == "record_item_specific":
+    name = tool_input["name"]
+    value = tool_input["value"]
+    item = await _get_or_create_item(seller_id, item_id, session)
+    attrs = dict(item.attributes or {})
+    attrs[name] = value
+    item.attributes = attrs
+    if item.required_specifics:
+        item.required_specifics = [
+            n for n in item.required_specifics if n != name
+        ]
+    await session.flush()
+    return f"Saved {name} = {value!r}", item.id
+```
+
+### [MODIFY] `packages/agents/intake/graph.py`
+
+`_plan_next_step` gets a new branch *before* the standard missing-fields
+check:
+
+```python
+if item.status == ItemStatus.needs_specifics and item.required_specifics:
+    next_field = item.required_specifics[0]
+    return (
+        f"To publish on eBay, I need to know the {next_field} of your item. "
+        "Could you tell me?",
+        False, False,
+    )
+
+if (
+    item.status == ItemStatus.needs_specifics
+    and not item.required_specifics
+):
+    # All specifics gathered — re-run publisher only.
+    item.status = ItemStatus.priced  # back to a state the publisher accepts
+    await session.flush()
+    _enqueue_publish_only(seller_id, item.id)
+    return (
+        "Thanks — I have everything I need. Re-publishing your listing now.",
+        False, True,
+    )
+```
+
+`SYSTEM_PROMPT` gains a section that fires only when the agent sees an item
+with `required_specifics`:
+
+```
+═══ FILLING MISSING eBay SPECIFICS ═══
+If the conversation history shows the seller answering a question about
+an item-specific (e.g. "Type", "Connectivity", "Colour", "Model"), call
+record_item_specific(name=<the field>, value=<the seller's answer>).
+Do NOT call record_attribute for these — they aren't core fields.
+```
+
+The branch reading these is in `intake_node`; we pass `required_specifics`
+into the system prompt context so the LLM knows which names to ask about.
+
+## Pipeline — publish-only re-entry
+
+### [MODIFY] `packages/agents/pipeline.py`
+
+Add a publisher-only entrypoint:
+
+```python
+async def run_publisher_only(seller_id: uuid.UUID, item_id: uuid.UUID) -> None:
+    """Re-run the publisher without re-pricing.
+
+    Called after intake clears item.required_specifics so the listing can
+    finally publish. Pricing already ran and is on the Item row.
+    """
+    from packages.db.session import SessionLocal
+    async with SessionLocal() as session:
+        item = await session.scalar(select(Item).where(Item.id == item_id))
+        if not item:
+            return
+        pricing = PricingResult(
+            item_id=item_id,
+            recommended_price=float(item.recommended_price or 0),
+            confidence_score=float(item.confidence_score or 0),
+            min_acceptable_price=float(item.min_acceptable_price or 0),
+        )
+        await run_publisher(
+            item_id=item_id, seller_id=seller_id, pricing=pricing, session=session,
+        )
+```
+
+### [MODIFY] `workers/sqs_worker.py`
+
+Register a new task `publish_only` mirroring the existing `run_pipeline`
+pattern:
+
+```python
+@register("publish_only")
+def handle_publish_only(seller_id: str, item_id: str) -> None:
+    from packages.agents.pipeline import run_publisher_only
+    asyncio.run(run_publisher_only(uuid.UUID(seller_id), uuid.UUID(item_id)))
+```
+
+### [MODIFY] `packages/agents/intake/graph.py` — `_enqueue_publish_only`
+
+```python
+def _enqueue_publish_only(seller_id, item_id):
+    if settings.sqs_queue_url:
+        from packages.bus.sqs import enqueue
+        enqueue("publish_only", seller_id=str(seller_id), item_id=str(item_id))
+    else:
+        # Local dev: run inline in a background task. The intake handler
+        # is itself reached through FastAPI BackgroundTasks, so we just
+        # schedule one more.
+        import asyncio
+        from packages.agents.pipeline import run_publisher_only
+        asyncio.create_task(run_publisher_only(seller_id, item_id))
+```
+
+Mirrors the existing intake-router fallback pattern.
+
+## Frontend exposure
+
+### [MODIFY] `apps/api/routers/intake.py` — listing status response
+
+The `/agent/intake/listing/{item_id}` endpoint already returns the listing
+state. Extend the response (or piggyback on `pricing/{item_id}`) to surface:
+
+```json
+{
+  "status": "needs_specifics",
+  "required_specifics": ["Type", "Connectivity", "Colour", "Model"]
+}
+```
+
+The frontend uses this to:
+- Show a "we need a few more details" banner
+- Resume the chat for that item so the seller can answer
+
+(Frontend code change is its own small follow-up; the API surface lands
+in this PR.)
+
+## Tests
+
+### Unit
+
+- `_parse_missing_specifics` — happy paths (single, multiple, dedup),
+  empty / unrelated error text → `[]`, multi-word names like
+  `"Storage Capacity"`, case insensitivity.
+- `record_item_specific` execution — writes to `attributes`, removes from
+  `required_specifics`, idempotent on duplicate calls.
+- `_plan_next_step` — `needs_specifics` + non-empty list → asks about
+  first item; empty list → triggers republish path; standard intake
+  unaffected when status is anything else.
+
+### Integration (deferred; needs DB fixture)
+
+- Full loop: simulate publisher 400 → status transitions → intake records
+  → publish_only re-runs → success.
+- Re-running pricing is **not** triggered (would burn LLM cost on the
+  validator).
+
+## Verification — manual end-to-end
+
+1. Start an intake for a Headphones item with sparse details (just
+   "Sony WH-1000XM5"), don't volunteer Type/Colour/Connectivity.
+2. Pricing runs, publisher attempts and writes `status=needs_specifics`,
+   `required_specifics=["Type", "Connectivity", "Colour", "Model"]`.
+3. Frontend resumes chat → agent asks about Type → seller answers.
+4. Repeat for each remaining specific.
+5. After the last one is recorded, intake triggers `publish_only`.
+6. Listing publishes, item.status → live.
+
+## Out of scope (future work)
+
+- Proactive Taxonomy API "preview" UX
+- Re-categorisation when eBay rejects category leaf
+- Rich frontend UI for "specifics waiting" beyond the chat resumption
+- Backward-compat for items already in `error` state from the old failure
+  mode (they'll need manual re-trigger or a one-off script)

--- a/tests/test_publisher_specifics_recovery.py
+++ b/tests/test_publisher_specifics_recovery.py
@@ -1,0 +1,48 @@
+"""Unit tests for the reactive specifics-recovery path on Agent 3.
+
+Covers the parser that pulls eBay 'item specific X is missing' names out of
+Trading API error strings. Integration tests that walk the publisher's full
+status branch are deferred until we have a DB-backed pytest fixture.
+"""
+
+from packages.agents.publisher.agent import _parse_missing_specifics
+
+
+def test_returns_empty_for_unrelated_error() -> None:
+    assert _parse_missing_specifics("Some other failure unrelated to specifics") == []
+
+
+def test_extracts_single_specific() -> None:
+    msg = "AddFixedPriceItem failed: The item specific Type is missing. Add Type to ..."
+    assert _parse_missing_specifics(msg) == ["Type"]
+
+
+def test_extracts_multiple_in_order() -> None:
+    msg = (
+        "Trading API failed: "
+        "The item specific Type is missing. Add Type ...; "
+        "The item specific Connectivity is missing. Add Connectivity ...; "
+        "The item specific Colour is missing. Add Colour ...; "
+        "The item specific Model is missing."
+    )
+    assert _parse_missing_specifics(msg) == ["Type", "Connectivity", "Colour", "Model"]
+
+
+def test_dedupes_repeated_names() -> None:
+    msg = "The item specific Type is missing. ... The item specific Type is missing again. ..."
+    assert _parse_missing_specifics(msg) == ["Type"]
+
+
+def test_extracts_multiword_names() -> None:
+    """eBay names like 'Storage Capacity' or 'Screen Size' must be captured intact."""
+    msg = "The item specific Storage Capacity is missing. Add Storage Capacity ..."
+    assert _parse_missing_specifics(msg) == ["Storage Capacity"]
+
+
+def test_case_insensitive_match() -> None:
+    msg = "The Item Specific Brand is missing. ..."
+    assert _parse_missing_specifics(msg) == ["Brand"]
+
+
+def test_empty_string() -> None:
+    assert _parse_missing_specifics("") == []

--- a/workers/sqs_worker.py
+++ b/workers/sqs_worker.py
@@ -50,6 +50,14 @@ def handle_run_pipeline(seller_id: str, item_id: str) -> None:
     asyncio.run(run_pipeline(uuid.UUID(seller_id), uuid.UUID(item_id)))
 
 
+@register("publish_only")
+def handle_publish_only(seller_id: str, item_id: str) -> None:
+    """Re-run the publisher only — used after intake fills missing specifics."""
+    from packages.agents.pipeline import run_publisher_only
+
+    asyncio.run(run_publisher_only(uuid.UUID(seller_id), uuid.UUID(item_id)))
+
+
 # ---------------------------------------------------------------------------
 # Worker loop
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Publisher v2 — Reactive Specifics Recovery Loop

## Overview
Currently, when eBay rejects a listing for missing item-specifics (e.g., `Type`, `Connectivity`, `Colour`, or `Model`), the publisher fails with `status=error` and the pipeline halts. 

**Publisher v2** makes this recoverable. Instead of relying on hardcoded fallbacks, the system now parses missing fields directly from eBay's error response, hands the item back to **Agent 1** (Intake) to query the seller, and automatically re-triggers the publisher once the data is collected.

## Why Reactive over Proactive?
We chose a reactive approach (parsing the eBay 400 error) over a proactive one (calling the Taxonomy API upfront) for the following reasons:
*   **Source of Truth:** eBay's error message is always current. This avoids issues with cache drift or schema differences between sandbox and production.
*   **Unified Error Handling:** We need error parsing anyway for other rejections (invalid enums, price floors, etc.). A reactive loop handles all these cases under one architecture.
*   **Efficiency:** Zero extra API calls on the "happy path" (successful listings).
*   **Extensibility:** A Taxonomy-backed "preview" can still be added later as a UI enhancement without refactoring the core logic.

Full design rationale is available in `publisher-agent-v2-implementation-plan.md`.

---

## State Machine Logic
The recovery loop inserts a new path into the item lifecycle:

`intake_complete` → `priced` → `publishing` ─────────► **`live`**  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;│  
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─► **`needs_specifics`** ─► (Intake collects) ─► `priced` ─► `publishing` ─► **`live`**

---

## Technical Changes

### Schema & Migrations
*   **New Enum Value:** Added `ItemStatus.needs_specifics`.
*   **New Column:** Added `Item.required_specifics` (`list[str] | None`) as a JSONB column to store outstanding fields.
*   **Migration `a1b2c3d4e5f6`:** Handles column addition and the non-transactional `ALTER TYPE` for the Postgres enum. 
    *   *Note: Down-migration drops the column, but leaves the enum value to avoid risky Postgres recreate-dances in production.*

### Publisher (`packages/agents/publisher/agent.py`)
Added a regex-based parser to identify missing specifics from eBay XML/JSON responses:
```python
_MISSING_SPECIFIC_RE = re.compile(
    r"item specific ([A-Za-z][A-Za-z0-9 &/\-]*?) is missing", re.IGNORECASE
)