### PR TITLE
feat: implement direct-answer guard for canned prompts, add Computer …

### DIFF
--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -37,6 +37,15 @@ logger = logging.getLogger(__name__)
 
 _CATEGORIES_STR = ", ".join(CATEGORY_LIST)
 
+# Canned prompts emitted by `_plan_next_step` when a core field is missing.
+# Module-level so the direct-answer guard can recognise its own prior output
+# in the chat history and route the seller's reply to the right field.
+_CANNED_FIELD_PROMPTS: dict[str, str] = {
+    "name": "What item are you looking to sell?",
+    "category": "What category does this item belong to? For example: Laptops, Trainers, Watches.",
+    "condition": "What condition is the item in? Choose from: new, like new, good, fair, or poor.",
+}
+
 SYSTEM_PROMPT = f"""\
 You are an AI assistant helping sellers create optimised eBay listings for \
 second-hand items. Your goal is to gather enough detail to produce an accurate, \
@@ -50,6 +59,7 @@ context and record it using record_attribute. Common categories: {_CATEGORIES_ST
 - "MacBook Pro 2021" → category = "Laptops"
 - "Samsung Galaxy S24" → category = "Phones"
 - "Bose QuietComfort 45" → category = "Headphones"
+- "Logitech G302 Gaming Mouse" → category = "Computer Peripherals"
 Only ask the seller to confirm the category if it is genuinely ambiguous \
 (e.g. "I want to sell some electronics" — could be anything).
 
@@ -156,6 +166,55 @@ def _missing_fields(item: Item) -> list[str]:
     return missing
 
 
+async def _apply_direct_answer_guard(
+    session: AsyncSession,
+    item_id: uuid.UUID,
+    messages: list[dict[str, Any]],
+) -> None:
+    """Record a canned-question answer directly if the LLM is about to mis-route it.
+
+    Why: when `_plan_next_step` asks a canned field question (e.g.
+    "What category does this item belong to?"), the LLM sometimes
+    misinterprets the seller's short reply as a new item description and
+    overwrites `name` instead of recording `category`, looping the
+    conversation. This guard short-circuits that by recognising the
+    prior canned prompt verbatim and writing the reply to the right field
+    before the LLM runs.
+    """
+    if len(messages) < 2 or messages[-1].get("role") != "user":
+        return
+    reply = (messages[-1].get("content") or "").strip()
+    if not reply or len(reply) > 80:
+        return
+    last_assistant = next(
+        (m for m in reversed(messages[:-1]) if m.get("role") == "assistant"),
+        None,
+    )
+    if not last_assistant:
+        return
+    prev = (last_assistant.get("content") or "").strip()
+    field = next((f for f, p in _CANNED_FIELD_PROMPTS.items() if p == prev), None)
+    if field is None:
+        return
+
+    item = await session.scalar(select(Item).where(Item.id == item_id))
+    if item is None:
+        return
+
+    if field == "category" and not (item.category or "").strip():
+        item.category = reply.title()
+    elif field == "name" and not (item.name or "").strip():
+        item.name = reply
+    elif field == "condition":
+        try:
+            item.condition = ItemCondition(reply.lower().replace(" ", "_"))
+        except ValueError:
+            return
+    else:
+        return
+    await session.flush()
+
+
 async def _plan_next_step(
     session: AsyncSession, item_id: uuid.UUID | None
 ) -> tuple[str | None, bool, bool]:
@@ -223,15 +282,10 @@ async def _plan_next_step(
         if not missing:
             return None, False, False
 
-        # Otherwise ask questions to fill in the missing fields
-        prompts = {
-            "name": "What item are you looking to sell?",
-            "category": "What category does this item belong to? For example: Laptops, Trainers, Watches.",
-            "condition": "What condition is the item in? Choose from: new, like new, good, fair, or poor.",
-            "description": None,  # Never ask seller for description — we generate it
-        }
+        # Otherwise ask questions to fill in the missing fields. Description
+        # is intentionally absent — we generate it via the LLM, never ask.
         for field in missing:
-            prompt = prompts.get(field)
+            prompt = _CANNED_FIELD_PROMPTS.get(field)
             if prompt:
                 return prompt, False, False
         return None, False, False
@@ -298,6 +352,12 @@ async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, A
     session = config["configurable"]["session"]
     seller_id = uuid.UUID(state["seller_id"])
     item_id = uuid.UUID(state["item_id"]) if state["item_id"] else None
+
+    # Direct-answer guard: if the previous assistant message was a canned
+    # field question, record the seller's reply against that field before
+    # the LLM gets a chance to mis-route it.
+    if item_id:
+        await _apply_direct_answer_guard(session, item_id, state["messages"])
 
     # Build system message — include enrichment hints if we know the category
     system_content = SYSTEM_PROMPT

--- a/packages/agents/intake/tools.py
+++ b/packages/agents/intake/tools.py
@@ -33,6 +33,7 @@ CATEGORY_LIST = [
     "Tablets",
     "Desktop Computers",
     "Monitors",
+    "Computer Peripherals",
     "Trainers",
     "Shoes",
     "Clothing",
@@ -70,6 +71,10 @@ _CATEGORY_KEYWORDS: tuple[tuple[tuple[str, ...], str], ...] = (
     (("ipad", "kindle", "tablet"), "Tablets"),
     (("iphone", "galaxy s", "pixel ", "smartphone", "phone"), "Phones"),
     (("monitor", "display"), "Monitors"),
+    (
+        ("mouse", "mice", "keyboard", "headset", "controller", "webcam", "mousepad"),
+        "Computer Peripherals",
+    ),
     (("trainer", "sneaker", "running shoe"), "Trainers"),
     (("shoe", "boot", "loafer", "sandal"), "Shoes"),
     (("watch", "smartwatch"), "Watches"),
@@ -131,6 +136,14 @@ CATEGORY_ENRICHMENT_HINTS: dict[str, list[str]] = {
         "screen size",
         "cellular or Wi-Fi only",
         "accessories included",
+    ],
+    "Computer Peripherals": [
+        "brand",
+        "model",
+        "type (mouse / keyboard / headset / etc.)",
+        "wired or wireless",
+        "colour",
+        "accessories included (cable, dongle, box)",
     ],
     "Trainers": [
         "brand",

--- a/packages/config.py
+++ b/packages/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
 
     openai_api_key: str = ""
     openai_base_url: str = ""
-    model_agent1: str = "gpt-5-nano-1"
+    model_agent1: str = "gpt-4.1-mini"
     model_agent2: str = "gpt-4.1-mini"  # relevance filter LLM for pricing comparables
     model_agent4: str = "gpt-4.1-mini"
 


### PR DESCRIPTION
# Summary

*   **Fixes Intake Agent Loop:** Resolves a critical bug where seller replies to category prompts were ignored or mis-routed into the `name` field, causing the agent to repeatedly ask, "What category does this item belong to?".
*   **Model Upgrade:** Upgrades Agent 1 (Intake) from `gpt-5-nano-1` to `gpt-4.1-mini`. The smaller reasoning model was found to be unreliable at correctly routing seller replies to specific tool fields.
*   **Defense in Depth:** Adds a deterministic direct-answer guard and widens category keyword inference to prevent loop recurrence even if the LLM mis-fires.

---

## What Changed

### `packages/config.py`
*   **Model Update:** Updated `model_agent1` from `gpt-5-nano-1` to `gpt-4.1-mini` to improve instruction following and tool-use consistency across the pipeline.

### `packages/agents/intake/tools.py`
*   **New Category:** Added `Computer Peripherals` to the global `CATEGORY_LIST`.
*   **Wider Inference:** Expanded `_CATEGORY_KEYWORDS` to include `mouse`, `mice`, `keyboard`, `headset`, `controller`, `webcam`, and `mousepad`. This allows `infer_category` to resolve gaming peripherals automatically from the item name.
*   **Enrichment Logic:** Added specific enrichment hints for peripherals, including brand, model, connectivity (wired/wireless), colour, and accessories.

### `packages/agents/intake/graph.py`
*   **Refactored Prompts:** Lifted the canned field-prompts dictionary to module scope as `_CANNED_FIELD_PROMPTS`. This ensures the planner and the new guard utilize a single source of truth for prompt identification.
*   **Direct-Answer Guard:** Implemented `_apply_direct_answer_guard()`. If the previous assistant message was a canned prompt, the system now automatically records the seller’s next reply against that specific field. 
    *   *Validation:* Includes length checks and enum validation to prevent the LLM from overwriting the `name` field with category data.
*   **Graph Integration:** Wired the guard into the `intake_node` to intercept messages before the LLM loop begins.
*   **System Prompt:** Added a logic example (`"Logitech G302 Gaming Mouse" → Computer Peripherals`) to reinforce peripheral category mapping in the LLM's context.

---

## Why Three Layers?

The solution implements **defense in depth**. While any single change might have resolved the immediate issue, together they cover multiple failure modes:

1.  **Keyword Fallback:** Handles cases where the LLM fails to call `record_attribute` entirely by looking at the item name.
2.  **Direct-Answer Guard:** Prevents loops when the LLM ignores a reply or mis-routes it to the wrong field after asking a direct question.
3.  **Stronger Model:** Reduces the frequency of the underlying logic failures that necessitate the first two layers.

**Note:** No database migrations are required for this deployment.

---

## Test Plan

### Automated
- [ ] Run `make test` and ensure all suites pass.

### Manual Verification (EC2)
1.  **Deploy:** Run `git pull && docker compose restart api`.
2.  **Zero-Prompt Inference:** 
    *   *Input:* "I want to sell my gaming mouse, Logitech G302"
    *   *Expectation:* Agent records both `name` and `category` (Computer Peripherals) and moves directly to enrichment.
3.  **Ambiguous Guard:** 
    *   *Input:* "I want to sell some electronics" → (Agent asks for category) → "Monitor"
    *   *Expectation:* The word "Monitor" is recorded in `items.category`, not `items.name`.
4.  **Database Integrity:** 
    *   Run `SELECT name, category FROM items ORDER BY created_at DESC LIMIT 3;`.
    *   Verify that a single conversation updates a single item row rather than creating orphan records.
5.  **Regression Check:** Verify existing categories (laptops, phones, trainers) still flow through the intake process normally.