### PR TITLE
fix: move tracing initialization to module-level and enable LANGCHAIN…

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -6,10 +6,10 @@ from packages.config import configure_tracing, settings
 
 configure_tracing()
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import FastAPI  # noqa: E402
+from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 
-from apps.api.routers import auth, ebay, health, images, intake, internal, pages, webhooks
+from apps.api.routers import auth, ebay, health, images, intake, internal, pages, webhooks  # noqa: E402
 
 # Surface app loggers (pricing/publisher/intake) at INFO so Round/Browse/etc.
 # messages are visible in `docker compose logs`. uvicorn configures its own

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -6,7 +6,7 @@ from packages.config import configure_tracing, settings
 
 configure_tracing()
 
-from fastapi import FastAPI  # noqa: E402
+from fastapi import FastAPI  # noqa: E402, I001
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 
 from apps.api.routers import auth, ebay, health, images, intake, internal, pages, webhooks  # noqa: E402

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,10 +1,15 @@
 import logging
 
+# Import config and activate tracing BEFORE any langsmith/langgraph imports,
+# since langsmith reads env vars at the time graphs are compiled (module level).
+from packages.config import configure_tracing, settings
+
+configure_tracing()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from apps.api.routers import auth, ebay, health, images, intake, internal, pages, webhooks
-from packages.config import configure_tracing, settings
 
 # Surface app loggers (pricing/publisher/intake) at INFO so Round/Browse/etc.
 # messages are visible in `docker compose logs`. uvicorn configures its own
@@ -16,9 +21,6 @@ logging.basicConfig(
 )
 # Belt-and-braces: uvicorn may have set the root level after basicConfig.
 logging.getLogger("packages").setLevel(logging.INFO)
-
-# Activate LangSmith tracing before any LangGraph graph is compiled
-configure_tracing()
 
 app = FastAPI(
     title="Multi-Agent Sales Assistant",

--- a/packages/config.py
+++ b/packages/config.py
@@ -113,5 +113,6 @@ def configure_tracing() -> None:
         return
 
     os.environ.setdefault("LANGSMITH_TRACING", "true")
+    os.environ.setdefault("LANGCHAIN_TRACING_V2", "true")  # LangGraph's callback tracer checks this
     os.environ.setdefault("LANGSMITH_API_KEY", settings.langsmith_api_key)
     os.environ.setdefault("LANGSMITH_PROJECT", settings.langsmith_project)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ extend-exclude = ["notebooks/*.ipynb"]
 select = ["E", "F", "W", "I", "B", "UP", "N", "SIM", "RUF"]
 ignore = ["E501", "B008"]
 
+[tool.ruff.lint.isort]
+known-first-party = ["apps", "packages", "workers"]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true


### PR DESCRIPTION
  1. main.py — configure_tracing() is now called before the router imports. The routers pull in packages.agents.intake.graph, which at module load compiles the LangGraph StateGraph and      
  imports from langsmith import traceable. All of that now happens after the env vars are in os.environ.                                                                                      
  2. config.py — configure_tracing() now also sets LANGCHAIN_TRACING_V2=true. LangGraph's internal callback-based tracer (used during graph.ainvoke) checks this variable; LANGSMITH_TRACING  
  alone only covers the @traceable decorator. 