### PR TITLE
feat: pre-bake Hugging Face models into Docker image and configure pe…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM public.ecr.aws/docker/library/python:3.12-slim
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1
+    UV_SYSTEM_PYTHON=1 \
+    HF_HOME=/opt/hf-cache
 
 WORKDIR /app
 
@@ -19,6 +20,14 @@ RUN uv pip install --system -e ".[nlp]"
 # spaCy ships without language models — download the small English model used
 # by packages/agents/nlp/entities.py. ~13 MB.
 RUN python -m spacy download en_core_web_sm
+
+# Pre-bake Hugging Face models into the image so the first buyer message
+# doesn't wait ~3 min for downloads. Cached at $HF_HOME (/opt/hf-cache).
+# Compose mounts a named volume here so the cache survives container
+# restarts AND new volumes get seeded from the image content on first run.
+RUN python -c "from transformers import pipeline; \
+    pipeline('zero-shot-classification', model='valhalla/distilbart-mnli-12-1'); \
+    pipeline('sentiment-analysis', model='cardiffnlp/twitter-roberta-base-sentiment-latest')"
 
 EXPOSE 8000
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,14 +33,19 @@ phases:
   build:
     on-failure: ABORT
     commands:
+      # Single shell block so `exit 0` from the branch guard short-circuits
+      # the entire deploy. Each `- |` is a separate sub-shell, so an early
+      # exit from one block does NOT skip the next.
       - |
-        # Only deploy when merging/pushing to main
+        set -e
+
+        # Only deploy when merging/pushing to main.
         BRANCH="${CODEBUILD_WEBHOOK_HEAD_REF:-}"
         if [ "$BRANCH" != "refs/heads/main" ]; then
           echo "Branch is '$BRANCH' — skipping deploy (main only)"
           exit 0
         fi
-      - |
+
         CMD_ID=$(aws ssm send-command \
           --region $AWS_REGION \
           --instance-ids $EC2_INSTANCE_ID \
@@ -57,10 +62,10 @@ phases:
           ]}' \
           --output text \
           --query "Command.CommandId")
-      - echo "SSM command $CMD_ID dispatched"
-      # 120 × 15s = 30 min. The image now installs torch/transformers/spaCy,
-      # so the first uncached `docker compose build` can take 10+ min.
-      - |
+        echo "SSM command $CMD_ID dispatched"
+
+        # 120 × 15s = 30 min. The image installs torch/transformers/spaCy and
+        # pre-bakes HF models, so the first uncached build can take 10+ min.
         for i in $(seq 1 120); do
           STATUS=$(aws ssm get-command-invocation \
             --region $AWS_REGION \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
+      # Persist Hugging Face model cache across container restarts.
+      # On first start the volume is seeded from the image's pre-baked /opt/hf-cache.
+      - hf_cache:/opt/hf-cache
     depends_on:
       postgres:
         condition: service_healthy
@@ -78,6 +81,8 @@ services:
       LANGSMITH_TRACING: ${LANGSMITH_TRACING:-false}
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY:-}
       LANGSMITH_PROJECT: ${LANGSMITH_PROJECT:-salesrep}
+    volumes:
+      - hf_cache:/opt/hf-cache
     depends_on:
       postgres:
         condition: service_healthy
@@ -85,3 +90,4 @@ services:
 volumes:
   postgres_data:
   minio_data:
+  hf_cache:


### PR DESCRIPTION
  Summary of changes:

  Dockerfile — added HF_HOME=/opt/hf-cache env, plus a RUN step that loads both transformer pipelines at build time so weights are pre-baked at /opt/hf-cache. Build will get ~1.5 GB heavier and take 1-2 min longer.

  docker-compose.yml — added a named volume hf_cache mounted at /opt/hf-cache on both api and sqs-worker. Docker's named-volume seeding behavior copies the pre-baked content from the image into the empty volume on first run, then preserves
  it across restarts.

  End result:
  - First deploy: image build is slow (downloads weights once), but the first buyer message is fast.
  - Subsequent deploys/restarts: instant — models load from the volume (or stay in memory if the container wasn't killed).
  - Image rebuilds with same model versions: still instant — the existing volume keeps the cached weights.
  - Model version change: if you swap to a different model in intent.py/sentiment.py, you'll want to nuke the volume so the new one gets seeded fresh: docker volume rm multi-agentic-sales-representative-system_hf_cache.

  Caveat: the RUN python -c "from transformers import pipeline; ..." step in the build will try to fetch from huggingface.co during build. CodeBuild has outbound internet, so this should work. If your CodeBuild env is in a locked-down VPC
  without egress, the build will hang here — let me know and we'll pre-cache in a different way (e.g. huggingface-cli download to a versioned S3 bucket and COPY it in).