### PR TITLE
Autonomy controls stale reprice

### DIFF
--- a/alembic/versions/0011_phase5_autonomy_and_offer_id.py
+++ b/alembic/versions/0011_phase5_autonomy_and_offer_id.py
@@ -1,0 +1,71 @@
+"""phase 5 autonomy + listing offer_id
+
+Adds the per-seller autonomy & stale-reprice settings (autonomy_level,
+stale_threshold_days, max_reprice_count) and the eBay offer ID on listings
+(needed by the reprice flow — update_offer_price keys on offer_id, not
+listing_id).
+
+Revision ID: 0011_phase5
+Revises: e12cea1746b1
+Create Date: 2026-05-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0011_phase5"
+down_revision: str | None = "e12cea1746b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_AUTONOMY_VALUES = ("draft", "auto_low_risk", "full_auto")
+
+
+def upgrade() -> None:
+    autonomy_enum = sa.Enum(*_AUTONOMY_VALUES, name="autonomy_level")
+    autonomy_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "autonomy_level",
+            autonomy_enum,
+            nullable=False,
+            server_default=sa.text("'draft'::autonomy_level"),
+        ),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "stale_threshold_days",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("7"),
+        ),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "max_reprice_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("3"),
+        ),
+    )
+
+    op.add_column(
+        "listings",
+        sa.Column("external_offer_id", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("listings", "external_offer_id")
+    op.drop_column("sellers", "max_reprice_count")
+    op.drop_column("sellers", "stale_threshold_days")
+    op.drop_column("sellers", "autonomy_level")
+    sa.Enum(name="autonomy_level").drop(op.get_bind(), checkfirst=True)

--- a/apps/api/routers/internal.py
+++ b/apps/api/routers/internal.py
@@ -5,10 +5,18 @@ In AWS: configure the EventBridge Scheduler target as an HTTP target with a stat
 Authorization header set to the value of INTERNAL_API_KEY.
 """
 
+import logging
+from datetime import UTC, datetime, timedelta
+
 from fastapi import APIRouter, Depends, HTTPException, Security, status
 from fastapi.security import APIKeyHeader
+from sqlalchemy import or_, select
 
 from packages.config import settings
+from packages.db.models import Listing, ListingStatus, Seller
+from packages.db.session import SessionLocal
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -32,3 +40,73 @@ def _require_internal_key(key: str | None = Security(_key_header)) -> None:
 )
 async def refresh_ebay_tokens() -> None:
     """Placeholder — refresh expiring eBay OAuth tokens for all sellers."""
+
+
+# Cooldown: don't enqueue the same listing more than once per day even if
+# EventBridge double-fires or the SQS task is re-delivered.
+_REPRICE_COOLDOWN_HOURS = 24
+
+
+@router.post(
+    "/check-stale-listings",
+    dependencies=[Depends(_require_internal_key)],
+)
+async def check_stale_listings() -> dict[str, int]:
+    """Find live listings overdue for a reprice and enqueue one task per listing.
+
+    A listing is "stale" when:
+      - status == live
+      - reprice_count < seller.max_reprice_count
+      - external_offer_id IS NOT NULL  (Trading-API listings can't be REST-repriced)
+      - last activity (last_buyer_interaction_at OR posted_at) is older than
+        seller.stale_threshold_days
+      - last_repriced_at is null OR older than the 24h cooldown
+
+    Returns a small JSON summary so EventBridge logs are useful.
+    """
+    now = datetime.now(UTC)
+    cooldown_cutoff = now - timedelta(hours=_REPRICE_COOLDOWN_HOURS)
+
+    enqueued = 0
+    skipped = 0
+
+    async with SessionLocal() as session:
+        rows = await session.execute(
+            select(Listing, Seller)
+            .join(Seller, Seller.id == Listing.seller_id)
+            .where(
+                Listing.status == ListingStatus.live,
+                Listing.external_offer_id.is_not(None),
+                Listing.reprice_count < Seller.max_reprice_count,
+                or_(
+                    Listing.last_repriced_at.is_(None),
+                    Listing.last_repriced_at < cooldown_cutoff,
+                ),
+            )
+        )
+
+        for listing, seller in rows.all():
+            staleness_cutoff = now - timedelta(days=seller.stale_threshold_days)
+            last_activity = listing.last_buyer_interaction_at or listing.posted_at
+            if last_activity is None or last_activity >= staleness_cutoff:
+                skipped += 1
+                continue
+
+            if settings.sqs_queue_url:
+                from packages.bus.sqs import enqueue
+
+                enqueue(
+                    "reprice_listing",
+                    seller_id=str(listing.seller_id),
+                    listing_id=str(listing.id),
+                )
+                enqueued += 1
+            else:
+                logger.warning(
+                    "[Stale check] SQS_QUEUE_URL unset — would enqueue reprice for %s",
+                    listing.id,
+                )
+                skipped += 1
+
+    logger.info("[Stale check] enqueued=%d skipped=%d", enqueued, skipped)
+    return {"enqueued": enqueued, "skipped": skipped}

--- a/apps/api/routers/webhooks.py
+++ b/apps/api/routers/webhooks.py
@@ -179,6 +179,11 @@ async def ebay_webhook_receive(
             received_at=datetime.now(UTC),
         )
         session.add(buyer_msg)
+
+        # Phase 5: any inbound buyer activity resets the stale-reprice timer.
+        if listing is not None:
+            listing.last_buyer_interaction_at = datetime.now(UTC)
+
         await session.commit()
 
         logger.info(

--- a/packages/agents/comms/graph.py
+++ b/packages/agents/comms/graph.py
@@ -40,15 +40,40 @@ from packages.agents.comms.tools import (
 )
 from packages.agents.nlp.pipeline import analyse_message
 from packages.config import settings
-from packages.db.models import BuyerMessage, Conversation, Item, Listing, Seller
+from packages.db.models import AutonomyLevel, BuyerMessage, Conversation, Item, Listing, Seller
 from packages.notifications import notify_seller
 from packages.platform_adapters.ebay.messaging import send_message
 from packages.schemas.nlp import NlpResult
 
 logger = logging.getLogger(__name__)
 
-# Intents that are considered "low risk" — auto-send the reply
-_AUTO_SEND_INTENTS = {"question", "greeting", "spam", "decline"}
+# Risk classification of each Agent 4 tool. Drives auto-send eligibility.
+#  - LOW_RISK: bounded informational/decline replies — safe to auto-send
+#  - APPROVAL_ONLY: side-effects the seller must confirm (a sale, an escalation)
+#  - everything else (counter_offer): higher-risk negotiation step
+_LOW_RISK_TOOLS = {"send_info", "decline_offer"}
+_APPROVAL_ONLY_TOOLS = {"accept_offer", "ask_seller"}
+
+
+def _resolve_requires_approval(autonomy: AutonomyLevel, tool_name: str | None) -> bool:
+    """Single source of truth for whether a reply needs seller approval.
+
+    `tool_name` may be None when the LLM responded with plain text (no tool
+    call); we treat that as a low-risk informational reply.
+    """
+    effective_tool = tool_name or "send_info"
+
+    if effective_tool in _APPROVAL_ONLY_TOOLS:
+        return True
+
+    if autonomy == AutonomyLevel.draft:
+        return True
+
+    if autonomy == AutonomyLevel.auto_low_risk:
+        return effective_tool not in _LOW_RISK_TOOLS
+
+    # full_auto: anything not in APPROVAL_ONLY_TOOLS is auto-sent
+    return False
 
 # System prompt template — NOTE: walk_away_price is NEVER included here
 _SYSTEM_PROMPT = """You are a professional sales assistant managing buyer inquiries on eBay.
@@ -181,6 +206,11 @@ async def agent_node(state: CommsState, config: RunnableConfig) -> dict[str, Any
             "requires_approval": True,
         }
 
+    # Load the seller to determine autonomy level. Default to the safest
+    # behaviour (draft) if the seller row is somehow missing.
+    seller = await session.get(Seller, seller_id)
+    autonomy: AutonomyLevel = seller.autonomy_level if seller else AutonomyLevel.draft
+
     listing = None
     item = None
     listed_price = 0.0
@@ -268,8 +298,8 @@ async def agent_node(state: CommsState, config: RunnableConfig) -> dict[str, Any
         ]
         if not function_tool_calls:
             draft_reply = msg.content or ""
-            action = "send" if nlp_result.intent in _AUTO_SEND_INTENTS else "draft"
-            requires_approval = nlp_result.intent not in _AUTO_SEND_INTENTS
+            requires_approval = _resolve_requires_approval(autonomy, tool_name=None)
+            action = "draft" if requires_approval else "send"
             break
 
         # Add assistant message (with tool_calls) to history
@@ -334,29 +364,19 @@ async def agent_node(state: CommsState, config: RunnableConfig) -> dict[str, Any
                 }
             )
 
-            # Determine action based on which tool was called
-            if tool_name == "send_info":
-                action = "send" if nlp_result.intent in _AUTO_SEND_INTENTS else "draft"
-                requires_approval = nlp_result.intent not in _AUTO_SEND_INTENTS
-                terminal_reply = tool_input.get("text", result_text)
-            elif tool_name == "accept_offer":
-                action = "draft"  # Acceptance always needs seller approval
-                requires_approval = True
+            # Action decision: autonomy level + tool risk class is the only
+            # source of truth (no intent-based override).
+            requires_approval = _resolve_requires_approval(autonomy, tool_name)
+            action = "draft" if requires_approval else "send"
+
+            if tool_name in {"accept_offer", "counter_offer"}:
                 offer_amount = tool_input.get("amount")
-                terminal_reply = tool_input.get("text", result_text)
-            elif tool_name == "counter_offer":
-                action = "draft"
-                requires_approval = True
-                offer_amount = tool_input.get("amount")
-                terminal_reply = tool_input.get("text", result_text)
-            elif tool_name == "decline_offer":
-                action = "send"  # Auto-send declines
-                requires_approval = False
                 terminal_reply = tool_input.get("text", result_text)
             elif tool_name == "ask_seller":
-                action = "draft"
-                requires_approval = True
                 terminal_reply = f"[ESCALATED TO SELLER] {tool_input.get('question', '')}"
+            else:
+                # send_info, decline_offer, or any unknown tool
+                terminal_reply = tool_input.get("text", result_text)
 
         if terminal_reply is not None:
             draft_reply = terminal_reply

--- a/packages/agents/comms/graph.py
+++ b/packages/agents/comms/graph.py
@@ -75,6 +75,7 @@ def _resolve_requires_approval(autonomy: AutonomyLevel, tool_name: str | None) -
     # full_auto: anything not in APPROVAL_ONLY_TOOLS is auto-sent
     return False
 
+
 # System prompt template — NOTE: walk_away_price is NEVER included here
 _SYSTEM_PROMPT = """You are a professional sales assistant managing buyer inquiries on eBay.
 You represent the seller and must be polite, helpful, and professional at all times.

--- a/packages/agents/pricing/reprice.py
+++ b/packages/agents/pricing/reprice.py
@@ -1,0 +1,162 @@
+"""Stale-listing reprice workflow (Phase 5).
+
+Triggered by the SQS task `reprice_listing`, itself enqueued by the
+EventBridge-driven `/internal/check-stale-listings` endpoint.
+
+For one listing:
+  1. Re-run Agent 2 to get a fresh PricingResult.
+  2. Apply guards: downward only, delta >= 3 %, and >= floor (the larger of
+     `seller_floor_price` and `min_acceptable_price`).
+  3. If allowed: call eBay `update_offer_price`, update the row, notify the seller.
+
+Listings without `external_offer_id` (legacy or Trading-API-only) are skipped
+with a log warning — the REST update endpoint cannot reach them.
+"""
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from langsmith import traceable
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from packages.agents.pricing.agent import run as run_pricing
+from packages.db.models import Item, Listing, ListingStatus, Seller
+from packages.notifications import notify_seller
+from packages.platform_adapters.ebay.sell import get_seller_token, update_offer_price
+
+logger = logging.getLogger(__name__)
+
+# Don't re-list a tiny price change — buyers won't notice a 1 % cut and we
+# burn an eBay API call + a reprice slot for nothing.
+_MIN_REPRICE_DELTA_RATIO = 0.03
+
+
+async def reprice_listing(
+    seller_id: uuid.UUID,
+    listing_id: uuid.UUID,
+    session: AsyncSession,
+) -> None:
+    """Reprice a single live listing if Agent 2 returns a meaningfully lower price."""
+    listing = await session.scalar(
+        select(Listing)
+        .where(Listing.id == listing_id, Listing.seller_id == seller_id)
+        .options(selectinload(Listing.item), selectinload(Listing.seller))
+    )
+    if listing is None:
+        logger.warning("[Reprice] listing %s not found for seller %s", listing_id, seller_id)
+        return
+
+    if listing.status != ListingStatus.live:
+        logger.info("[Reprice] skipping listing %s — status=%s", listing_id, listing.status)
+        return
+
+    if not listing.external_offer_id:
+        logger.warning(
+            "[Reprice] listing %s has no external_offer_id (Trading-API path?) — skipping",
+            listing_id,
+        )
+        return
+
+    seller: Seller = listing.seller
+    if listing.reprice_count >= seller.max_reprice_count:
+        logger.info(
+            "[Reprice] listing %s already at max_reprice_count=%s — skipping",
+            listing_id,
+            seller.max_reprice_count,
+        )
+        return
+
+    item: Item = listing.item
+
+    # Re-run Agent 2 with the same item context to get a fresh recommendation.
+    pricing = await run_pricing(item_id=item.id, seller_id=seller_id, session=session)
+    new_price = float(pricing.recommended_price or 0)
+    old_price = float(listing.posted_price or 0)
+
+    if new_price <= 0 or old_price <= 0:
+        logger.info(
+            "[Reprice] listing %s — invalid prices (new=%.2f old=%.2f)",
+            listing_id,
+            new_price,
+            old_price,
+        )
+        return
+
+    # Guard 1: only reprice downward.
+    if new_price >= old_price:
+        logger.info(
+            "[Reprice] listing %s — new price %.2f not below old %.2f, skipping",
+            listing_id,
+            new_price,
+            old_price,
+        )
+        return
+
+    # Guard 2: meaningful delta only.
+    delta_ratio = (old_price - new_price) / old_price
+    if delta_ratio < _MIN_REPRICE_DELTA_RATIO:
+        logger.info(
+            "[Reprice] listing %s — delta %.1f%% below %.0f%% threshold, skipping",
+            listing_id,
+            delta_ratio * 100,
+            _MIN_REPRICE_DELTA_RATIO * 100,
+        )
+        return
+
+    # Guard 3: never go below the seller's floor.
+    floor = float(item.seller_floor_price or item.min_acceptable_price or 0)
+    if floor and new_price < floor:
+        logger.info(
+            "[Reprice] listing %s — new price %.2f below floor %.2f, skipping",
+            listing_id,
+            new_price,
+            floor,
+        )
+        return
+
+    # All guards passed — push the new price to eBay.
+    token = await get_seller_token(seller_id, session)
+    await update_offer_price(listing.external_offer_id, new_price, token)
+
+    listing.posted_price = new_price
+    listing.last_repriced_at = datetime.now(UTC)
+    listing.reprice_count += 1
+    await session.commit()
+
+    logger.info(
+        "[Reprice] listing %s repriced %.2f -> %.2f (count=%d)",
+        listing_id,
+        old_price,
+        new_price,
+        listing.reprice_count,
+    )
+
+    if seller.sns_topic_arn:
+        notify_seller(
+            seller.sns_topic_arn,
+            subject=f"Listing repriced: {item.name[:60]}",
+            message=(
+                f"Your listing '{item.name}' was automatically repriced.\n"
+                f"  Old price: £{old_price:.2f}\n"
+                f"  New price: £{new_price:.2f}\n"
+                f"  Reprice count: {listing.reprice_count} of {seller.max_reprice_count}"
+            ),
+        )
+
+
+@traceable(name="reprice_listing", run_type="chain")
+async def reprice_listing_task(seller_id: uuid.UUID, listing_id: uuid.UUID) -> None:
+    """SQS entry point — opens its own DB session."""
+    from packages.db.session import SessionLocal
+
+    async with SessionLocal() as session:
+        try:
+            await reprice_listing(seller_id, listing_id, session)
+        except Exception:
+            logger.exception(
+                "[Reprice] failed for seller=%s listing=%s", seller_id, listing_id
+            )
+            raise

--- a/packages/agents/pricing/reprice.py
+++ b/packages/agents/pricing/reprice.py
@@ -156,7 +156,5 @@ async def reprice_listing_task(seller_id: uuid.UUID, listing_id: uuid.UUID) -> N
         try:
             await reprice_listing(seller_id, listing_id, session)
         except Exception:
-            logger.exception(
-                "[Reprice] failed for seller=%s listing=%s", seller_id, listing_id
-            )
+            logger.exception("[Reprice] failed for seller=%s listing=%s", seller_id, listing_id)
             raise

--- a/packages/agents/publisher/agent.py
+++ b/packages/agents/publisher/agent.py
@@ -175,6 +175,9 @@ async def run(
             token=token,
             merchant_location_key=location_key,
         )
+        # Persist the offer ID so the stale-reprice flow can call
+        # update_offer_price without an extra SKU→offer lookup.
+        listing.external_offer_id = offer_result.offer_id
 
         # Step 8: Publish offer (Trading API fallback handles Item.Country in sandbox)
         publish_result = await publish_offer(

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -83,6 +83,13 @@ class NegotiationStatus(enum.StrEnum):
     seller_review = "seller_review"  # Agent escalated to seller for approval
 
 
+class AutonomyLevel(enum.StrEnum):
+    # Per-seller cap on how much Agent 4 may send without approval.
+    draft = "draft"  # Every reply requires seller approval
+    auto_low_risk = "auto_low_risk"  # Auto-send send_info + decline_offer
+    full_auto = "full_auto"  # Auto-send everything except sale acceptance and seller escalation
+
+
 # --- MODELS ---
 class Seller(Base):
     __tablename__ = "sellers"
@@ -99,6 +106,17 @@ class Seller(Base):
 
     # SNS notification topic (if enabled)
     sns_topic_arn: Mapped[str | None] = mapped_column(String(2048))
+
+    # Phase 5 — autonomy & stale-reprice settings
+    autonomy_level: Mapped[AutonomyLevel] = mapped_column(
+        Enum(AutonomyLevel, name="autonomy_level"),
+        nullable=False,
+        default=AutonomyLevel.draft,
+    )
+    # Days a listing can sit without buyer interaction before it qualifies for reprice
+    stale_threshold_days: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
+    # Hard cap on automatic reprices per listing
+    max_reprice_count: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
 
     # Auto-managed timestamps (DB-side defaults)
     created_at: Mapped[datetime] = mapped_column(
@@ -399,6 +417,10 @@ class Listing(Base):
 
     # External identifiers from the marketplace
     external_id: Mapped[str | None] = mapped_column(String(255))  # eBay listing ID
+    # eBay offer ID — needed by /sell/inventory/v1/offer/{offer_id} for repricing.
+    # Null for Trading-API-only listings (sandbox fallback path), which can't be
+    # repriced through update_offer_price.
+    external_offer_id: Mapped[str | None] = mapped_column(String(255))
     url: Mapped[str | None] = mapped_column(String(2048))  # Live listing URL
 
     # Listing lifecycle status
@@ -820,3 +842,4 @@ class EntityMention(Base):
     buyer_message: Mapped["BuyerMessage"] = relationship(
         "BuyerMessage", back_populates="entity_mentions"
     )
+

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -842,4 +842,3 @@ class EntityMention(Base):
     buyer_message: Mapped["BuyerMessage"] = relationship(
         "BuyerMessage", back_populates="entity_mentions"
     )
-

--- a/workers/sqs_worker.py
+++ b/workers/sqs_worker.py
@@ -92,6 +92,14 @@ def handle_retry_buyer_message(clarification_request_id: str) -> None:
     asyncio.run(_run())
 
 
+@register("reprice_listing")
+def handle_reprice_listing(seller_id: str, listing_id: str) -> None:
+    """Phase 5 stale-listing reprice — Agent 2 → eBay update_offer_price."""
+    from packages.agents.pricing.reprice import reprice_listing_task
+
+    asyncio.run(reprice_listing_task(uuid.UUID(seller_id), uuid.UUID(listing_id)))
+
+
 # ---------------------------------------------------------------------------
 # Worker loop
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Phase 5: Per-seller autonomy controls + automatic stale-listing reprice

Adds the two operator-facing knobs from Phase 5 of the implementation plan:

1.  **Autonomy levels** so each seller can choose how much Agent 4 sends without approval (`draft` / `auto_low_risk` / `full_auto`).
2.  **Stale-listing reprice** — a nightly EventBridge job reruns Agent 2 on listings that have been live with no buyer interaction, and pushes a lower price to eBay if (and only if) all of the safety guards pass.

---

## Schema (migration `0011_phase5_autonomy_and_offer_id`)

| Table | Column | Default | Purpose |
| :--- | :--- | :--- | :--- |
| `sellers` | `autonomy_level` (enum) | `draft` | How much Agent 4 may auto-send |
| `sellers` | `stale_threshold_days` | `7` | Days idle before a listing qualifies for reprice |
| `sellers` | `max_reprice_count` | `3` | Hard cap on automatic reprices per listing |
| `listings` | `external_offer_id` | `NULL` | eBay *offer* ID (needed by `update_offer_price`) |

> **Note:** The plan originally proposed calling `update_offer_price(listing.external_id, ...)` which would target the wrong eBay resource. We persist the `offer_id` at publish time instead for a clean lookup without extra API calls.

---

## Autonomy Logic — Single Source of Truth

The previous comms graph mixed two overlapping rule sets. This PR removes the hardcoded intent set and replaces it with one unified helper:

`def _resolve_requires_approval(autonomy: AutonomyLevel, tool_name: str | None) -> bool`

### Tool Risk Classification

| Tool | Class | Behaviour |
| :--- | :--- | :--- |
| `send_info` | low-risk | Auto-send when autonomy ≥ `auto_low_risk` |
| `decline_offer` | low-risk | Auto-send when autonomy ≥ `auto_low_risk` |
| `counter_offer` | high-risk | Auto-send only on `full_auto` |
| `accept_offer` | approval-only | Always requires approval (sale finalisation) |
| `ask_seller` | approval-only | Always requires approval (escalation) |

*Plain-text replies (no tool call) are treated as `send_info`.*

---

## Stale Reprice Flow

1.  **EventBridge cron** (nightly)
2.  **POST** `/internal/check-stale-listings` (X-Internal-Key)
3.  **SQS task**: `reprice_listing` (one task per stale listing)
4.  **Worker** (`packages/agents/pricing/reprice.py`):
    *   Re-run Agent 2 → fresh `PricingResult`.
    *   Apply guards.
    *   `update_offer_price(offer_id, new_price)` on eBay.
    *   Persist (`posted_price`, `last_repriced_at`, `++reprice_count`).
    *   SNS notify seller.

### Guards (All must pass):
1.  Listing status is `live` and has an `external_offer_id`.
2.  `reprice_count` < `seller.max_reprice_count`.
3.  New price is strictly lower than `posted_price` (no upward drift).
4.  Delta is at least 3% (no nuisance reprices).
5.  New price ≥ `seller_floor_price` (or `min_acceptable_price` if floor is unset).

---

## Files Changed

| File | Change |
| :--- | :--- |
| `alembic/versions/0011_...` | New migration. |
| `packages/db/models.py` | `AutonomyLevel` enum, 3 new Seller columns, `Listing.external_offer_id`. |
| `packages/agents/publisher/agent.py` | Persist `offer_id` onto the listing row. |
| `packages/agents/comms/graph.py` | Replace `_AUTO_SEND_INTENTS` with unified approval helper. |
| `packages/agents/pricing/reprice.py` | New workflow + SQS task entry. |
| `apps/api/routers/internal.py` | New endpoint: `POST /internal/check-stale-listings`. |
| `apps/api/routers/webhooks.py` | Bump `last_buyer_interaction_at` on inbound messages. |
| `workers/sqs_worker.py` | Register `@register("reprice_listing")` handler. |

---

## Out of Scope (Deferred)

*   **Settings UI** — Autonomy level changes remain backend-only for this phase.
*   **Trading-API Listing Reprice** — Skipped; requires `ReviseFixedPriceItem` path.
*   **Reprice History Page** — Data is stored on the row; UI surfacing is a follow-up.

---

## Test Plan

*   `make migrate` on a clean local DB — schema applies cleanly.
*   `make ci` passes (lint, format, mypy, tests).
*   **Autonomy testing**: Confirm `auto_low_risk` auto-sends info/declines while `counter_offer` drafts.
*   **Safety testing**: Confirm `accept_offer` still drafts even on `full_auto`.
*   **Manual Trigger**: `curl -X POST .../internal/check-stale-listings` and verify SQS logs.
*   **E2E**: Force `last_buyer_interaction_at` to 30 days ago and verify the eBay price update + SNS fire.