### PR TITLE
Prod readiness hmac and sale fix

### DIFF
--- a/apps/api/routers/webhooks.py
+++ b/apps/api/routers/webhooks.py
@@ -16,7 +16,10 @@ from sqlalchemy import select
 from packages.config import settings
 from packages.db.models import BuyerMessage, Conversation, Listing, MessageDirection
 from packages.db.session import SessionLocal
-from packages.platform_adapters.ebay.webhooks import validate_endpoint_challenge
+from packages.platform_adapters.ebay.webhooks import (
+    validate_endpoint_challenge,
+    verify_signature,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,25 +41,18 @@ async def ebay_webhook_challenge(challenge_code: str) -> Response:
         return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
-def _validate_hmac(signature_header: str | None, payload: bytes) -> bool:
-    """Validate the HMAC signature from eBay.
+async def _validate_signature(signature_header: str | None, payload: bytes) -> bool:
+    """Validate the inbound webhook's `X-EBAY-SIGNATURE`.
 
-    Returns True if the signature is valid or HMAC validation is skipped.
+    Real SHA1-with-ECDSA verification against the public key fetched from
+    eBay's Notification API (cached for ~1 h). Bypassed only when
+    `SKIP_WEBHOOK_HMAC=true` — keep that off in production.
     """
     if settings.skip_webhook_hmac:
-        logger.debug("HMAC validation skipped (SKIP_WEBHOOK_HMAC=true)")
+        logger.debug("Signature validation skipped (SKIP_WEBHOOK_HMAC=true)")
         return True
 
-    if not signature_header:
-        logger.warning("No X-EBAY-SIGNATURE header present")
-        return False
-
-    # eBay's signature validation is complex (involves fetching their public key).
-    # For now, we validate the presence of the header. Full ECDSA validation
-    # can be added when moving to production.
-    # TODO: Implement full eBay ECDSA signature validation
-    logger.info("HMAC header present: %s", signature_header[:50])
-    return True
+    return await verify_signature(signature_header, payload)
 
 
 @router.post("/webhook")
@@ -77,10 +73,10 @@ async def ebay_webhook_receive(
     payload = await request.body()
     signature_header = request.headers.get("X-EBAY-SIGNATURE")
 
-    logger.info("Received eBay webhook notification. Signature: %s", signature_header)
+    logger.info("Received eBay webhook notification. Signature header present: %s", bool(signature_header))
 
-    # --- 1. Validate HMAC ---
-    if not _validate_hmac(signature_header, payload):
+    # --- 1. Validate signature ---
+    if not await _validate_signature(signature_header, payload):
         return Response(status_code=status.HTTP_401_UNAUTHORIZED)
 
     # --- 2. Parse payload ---

--- a/apps/api/routers/webhooks.py
+++ b/apps/api/routers/webhooks.py
@@ -73,7 +73,9 @@ async def ebay_webhook_receive(
     payload = await request.body()
     signature_header = request.headers.get("X-EBAY-SIGNATURE")
 
-    logger.info("Received eBay webhook notification. Signature header present: %s", bool(signature_header))
+    logger.info(
+        "Received eBay webhook notification. Signature header present: %s", bool(signature_header)
+    )
 
     # --- 1. Validate signature ---
     if not await _validate_signature(signature_header, payload):

--- a/packages/platform_adapters/ebay/webhooks.py
+++ b/packages/platform_adapters/ebay/webhooks.py
@@ -1,15 +1,72 @@
+"""eBay Event Notification webhook helpers.
+
+Two responsibilities:
+  1. Endpoint-validation challenge (`validate_endpoint_challenge`) — called from
+     the GET handler when eBay sets up the destination.
+  2. Push-notification signature verification (`verify_signature`) — called from
+     the POST handler on every inbound notification.
+
+The signature scheme (per eBay's Notification API docs):
+  - `X-EBAY-SIGNATURE` is base64-encoded JSON:
+        {"alg":"ECDSA","kid":"<key-id>","signature":"<base64>","digest":"SHA1"}
+  - The signed bytes are the **raw HTTP body** of the notification.
+  - The verifier algorithm is SHA1-with-ECDSA over the raw body.
+  - The public key is fetched from
+        GET /commerce/notification/v1/public_key/{kid}
+    using an app-level OAuth token (client credentials) and is X.509 PEM
+    encoded — eBay recommends caching it for ~1 hour to avoid rate limits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
 import hashlib
+import json
 import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 
 from packages.config import settings
 
 logger = logging.getLogger(__name__)
 
 
+# eBay's Notification public_key endpoint (env-routed, same split as Browse)
+_PUBLIC_KEY_BASE = {
+    "sandbox": "https://api.sandbox.ebay.com/commerce/notification/v1/public_key",
+    "production": "https://api.ebay.com/commerce/notification/v1/public_key",
+}
+
+_TOKEN_URL = {
+    "sandbox": "https://api.sandbox.ebay.com/identity/v1/oauth2/token",
+    "production": "https://api.ebay.com/identity/v1/oauth2/token",
+}
+
+_NOTIFICATION_SCOPE = "https://api.ebay.com/oauth/api_scope"
+
+# Cache TTLs — eBay's docs recommend ~1 hour for the public key. Tokens get
+# refreshed 60 s before expiry to avoid edge-case 401s.
+_PUBLIC_KEY_TTL_SECONDS = 3600
+_APP_TOKEN_REFRESH_LEAD_SECONDS = 60
+
+
+# ---------------------------------------------------------------------------
+# Endpoint validation (GET challenge)
+# ---------------------------------------------------------------------------
+
+
 def validate_endpoint_challenge(challenge_code: str) -> str:
-    """
-    Computes the SHA-256 hash of challengeCode + verificationToken + endpoint
-    required for eBay Event Notification validation.
+    """SHA-256(challengeCode + verificationToken + endpoint), hex-encoded.
+
+    Returned string is the value of the `challengeResponse` JSON field that
+    eBay's GET /webhook handshake expects.
     """
     verification_token = settings.ebay_verification_token
     endpoint = settings.ebay_webhook_endpoint
@@ -18,8 +75,196 @@ def validate_endpoint_challenge(challenge_code: str) -> str:
         logger.error("ebay_verification_token or ebay_webhook_endpoint is missing in settings")
         raise ValueError("Missing webhook configuration")
 
-    hash_input = f"{challenge_code}{verification_token}{endpoint}"
+    sha256 = hashlib.sha256()
+    sha256.update(challenge_code.encode("utf-8"))
+    sha256.update(verification_token.encode("utf-8"))
+    sha256.update(endpoint.encode("utf-8"))
+    return sha256.hexdigest()
 
-    sha256_hash = hashlib.sha256()
-    sha256_hash.update(hash_input.encode("utf-8"))
-    return sha256_hash.hexdigest()
+
+# ---------------------------------------------------------------------------
+# App-token cache (for fetching the public key)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CachedToken:
+    access_token: str
+    expires_at: float  # epoch seconds
+
+
+_app_token: _CachedToken | None = None
+_token_lock = asyncio.Lock()
+
+
+def _ebay_env() -> str:
+    return "sandbox" if settings.ebay_env == "sandbox" else "production"
+
+
+async def _get_app_token() -> str:
+    """Client-credentials token for calling the Notification API."""
+    global _app_token
+    async with _token_lock:
+        now = time.time()
+        if _app_token and _app_token.expires_at > now:
+            return _app_token.access_token
+
+        creds = f"{settings.ebay_client_id}:{settings.ebay_client_secret}"
+        basic = base64.b64encode(creds.encode()).decode()
+
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(
+                _TOKEN_URL[_ebay_env()],
+                headers={
+                    "Authorization": f"Basic {basic}",
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                data={"grant_type": "client_credentials", "scope": _NOTIFICATION_SCOPE},
+            )
+            r.raise_for_status()
+            data = r.json()
+
+        _app_token = _CachedToken(
+            access_token=data["access_token"],
+            expires_at=now + int(data["expires_in"]) - _APP_TOKEN_REFRESH_LEAD_SECONDS,
+        )
+        return _app_token.access_token
+
+
+# ---------------------------------------------------------------------------
+# Public-key cache (per kid)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _CachedKey:
+    pem_bytes: bytes
+    expires_at: float
+
+
+_public_keys: dict[str, _CachedKey] = {}
+_key_lock = asyncio.Lock()
+
+
+async def _get_public_key(kid: str) -> ec.EllipticCurvePublicKey:
+    """Fetch and cache the EC public key for `kid`."""
+    async with _key_lock:
+        now = time.time()
+        cached = _public_keys.get(kid)
+        if cached and cached.expires_at > now:
+            return _load_ec_key(cached.pem_bytes)
+
+        token = await _get_app_token()
+        url = f"{_PUBLIC_KEY_BASE[_ebay_env()]}/{kid}"
+
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+            r.raise_for_status()
+            payload = r.json()
+
+        # eBay returns the key as a PEM string under `key`. Normalise: strip
+        # any leading/trailing whitespace so `serialization.load_pem_*`
+        # accepts it cleanly.
+        pem_str = payload.get("key", "").strip()
+        if not pem_str:
+            raise ValueError(f"getPublicKey response for kid={kid} missing 'key' field")
+
+        # Some responses come back as a single-line "-----BEGIN PUBLIC KEY----- AAA... -----END PUBLIC KEY-----"
+        # without internal newlines, which cryptography rejects. Insert linebreaks if needed.
+        pem_bytes = _normalise_pem(pem_str).encode("utf-8")
+
+        _public_keys[kid] = _CachedKey(
+            pem_bytes=pem_bytes, expires_at=now + _PUBLIC_KEY_TTL_SECONDS
+        )
+        return _load_ec_key(pem_bytes)
+
+
+def _normalise_pem(pem: str) -> str:
+    """Ensure the PEM has proper line breaks between header/body/footer."""
+    if "\n" in pem:
+        return pem
+    if pem.startswith("-----BEGIN") and "-----END" in pem:
+        # Split header / body / footer, re-wrap body at 64 chars.
+        try:
+            header, rest = pem.split("-----", 2)[1], pem.split("-----", 2)[2]
+            # rest starts with the body + footer
+            body_and_footer = rest.split("-----")
+            body = body_and_footer[0].strip().replace(" ", "")
+            footer = "-----" + body_and_footer[1] + "-----" + body_and_footer[2]
+            wrapped = "\n".join(body[i : i + 64] for i in range(0, len(body), 64))
+            return f"-----{header}-----\n{wrapped}\n{footer}".strip()
+        except IndexError:
+            return pem
+    return pem
+
+
+def _load_ec_key(pem_bytes: bytes) -> ec.EllipticCurvePublicKey:
+    key = serialization.load_pem_public_key(pem_bytes)
+    if not isinstance(key, ec.EllipticCurvePublicKey):
+        raise ValueError(f"Expected EC public key, got {type(key).__name__}")
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+async def verify_signature(signature_header: str | None, payload: bytes) -> bool:
+    """Verify an inbound eBay notification's `X-EBAY-SIGNATURE`.
+
+    Returns True only when the signature is valid for the supplied payload
+    bytes. Any decode/network/key error is logged and returns False so the
+    caller can respond 401 without leaking implementation detail.
+    """
+    if not signature_header:
+        logger.warning("verify_signature: no X-EBAY-SIGNATURE header")
+        return False
+
+    try:
+        decoded = base64.b64decode(signature_header)
+        envelope = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        logger.warning("verify_signature: header is not base64-encoded JSON")
+        return False
+
+    kid = envelope.get("kid")
+    sig_b64 = envelope.get("signature")
+    alg = envelope.get("alg", "").upper()
+    digest = envelope.get("digest", "").upper()
+
+    if not kid or not sig_b64 or alg != "ECDSA" or digest != "SHA1":
+        logger.warning(
+            "verify_signature: unexpected envelope (alg=%s digest=%s kid_present=%s)",
+            alg,
+            digest,
+            bool(kid),
+        )
+        return False
+
+    try:
+        signature = base64.b64decode(sig_b64)
+    except ValueError:
+        logger.warning("verify_signature: signature field is not base64")
+        return False
+
+    try:
+        public_key = await _get_public_key(kid)
+    except (httpx.HTTPError, ValueError):
+        logger.exception("verify_signature: failed to fetch public key for kid=%s", kid)
+        return False
+
+    # eBay signs the raw HTTP body with SHA1-ECDSA. We hash here ourselves so
+    # the cryptography call uses Prehashed — same result, but lets us reuse
+    # the digest if we ever want to log it.
+    sha1 = hashlib.sha1(payload).digest()  # noqa: S324 — eBay's spec uses SHA1
+    try:
+        public_key.verify(signature, sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
+    except InvalidSignature:
+        logger.warning("verify_signature: signature did not validate (kid=%s)", kid)
+        return False
+    except Exception:
+        logger.exception("verify_signature: unexpected verifier error")
+        return False
+
+    return True

--- a/packages/platform_adapters/ebay/webhooks.py
+++ b/packages/platform_adapters/ebay/webhooks.py
@@ -257,7 +257,7 @@ async def verify_signature(signature_header: str | None, payload: bytes) -> bool
     # eBay signs the raw HTTP body with SHA1-ECDSA. We hash here ourselves so
     # the cryptography call uses Prehashed — same result, but lets us reuse
     # the digest if we ever want to log it.
-    sha1 = hashlib.sha1(payload).digest()  # noqa: S324 — eBay's spec uses SHA1
+    sha1 = hashlib.sha1(payload).digest()
     try:
         public_key.verify(signature, sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
     except InvalidSignature:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,12 @@ packages = ["apps", "packages", "workers"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Share one event loop across the whole test session. The app's async engine
+# (packages.db.session.engine) is module-level and binds its asyncpg
+# connections to the first event loop that touches them; per-test loops
+# trigger "another operation in progress" on the second test that uses the DB.
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 addopts = "-ra --strict-markers"
 
 [tool.ruff]

--- a/tests/test_webhook_signature.py
+++ b/tests/test_webhook_signature.py
@@ -13,7 +13,7 @@ import hashlib
 import json
 
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 
@@ -22,7 +22,7 @@ from packages.platform_adapters.ebay import webhooks as ebay_webhooks
 
 def _build_signed_envelope(payload: bytes, kid: str, private_key) -> str:
     """Sign `payload` with SHA1-ECDSA, return the base64 envelope eBay would send."""
-    sha1 = hashlib.sha1(payload).digest()  # noqa: S324 — eBay's spec uses SHA1
+    sha1 = hashlib.sha1(payload).digest()
     signature = private_key.sign(sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
     envelope = {
         "alg": "ECDSA",
@@ -71,7 +71,7 @@ async def test_verify_signature_rejects_tampered_payload(keypair_and_kid):
 async def test_verify_signature_rejects_wrong_algorithm(keypair_and_kid):
     private_key, kid = keypair_and_kid
     payload = b"{}"
-    sha1 = hashlib.sha1(payload).digest()  # noqa: S324
+    sha1 = hashlib.sha1(payload).digest()
     signature = private_key.sign(sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
     bad_envelope = base64.b64encode(
         json.dumps(
@@ -104,18 +104,14 @@ def test_normalise_pem_inserts_linebreaks_into_single_line_pem():
 
     assert normalised.startswith("-----BEGIN PUBLIC KEY-----\n")
     assert normalised.endswith("\n-----END PUBLIC KEY-----")
-    body_lines = [
-        line for line in normalised.splitlines() if not line.startswith("-----")
-    ]
+    body_lines = [line for line in normalised.splitlines() if not line.startswith("-----")]
     assert all(len(line) <= 64 for line in body_lines)
     assert "".join(body_lines) == body
 
 
 def test_normalise_pem_passthrough_when_already_multiline():
     pem = (
-        "-----BEGIN PUBLIC KEY-----\n"
-        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n"
-        "-----END PUBLIC KEY-----"
+        "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n-----END PUBLIC KEY-----"
     )
     assert ebay_webhooks._normalise_pem(pem) == pem
 

--- a/tests/test_webhook_signature.py
+++ b/tests/test_webhook_signature.py
@@ -1,0 +1,134 @@
+"""Tests for the eBay X-EBAY-SIGNATURE verifier.
+
+Generates a real EC keypair, signs a payload locally, monkey-patches the
+public-key fetcher to return our test key, and confirms `verify_signature`:
+  - accepts the valid signature against the original payload
+  - rejects a tampered payload
+  - rejects when the envelope is malformed (wrong alg/digest/missing kid)
+  - rejects when no header is supplied
+"""
+
+import base64
+import hashlib
+import json
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+
+from packages.platform_adapters.ebay import webhooks as ebay_webhooks
+
+
+def _build_signed_envelope(payload: bytes, kid: str, private_key) -> str:
+    """Sign `payload` with SHA1-ECDSA, return the base64 envelope eBay would send."""
+    sha1 = hashlib.sha1(payload).digest()  # noqa: S324 — eBay's spec uses SHA1
+    signature = private_key.sign(sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
+    envelope = {
+        "alg": "ECDSA",
+        "kid": kid,
+        "signature": base64.b64encode(signature).decode(),
+        "digest": "SHA1",
+    }
+    return base64.b64encode(json.dumps(envelope).encode()).decode()
+
+
+@pytest.fixture
+def keypair_and_kid(monkeypatch):
+    """Generate a fresh EC keypair and patch _get_public_key to return it."""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    public_key = private_key.public_key()
+    kid = "test-kid-abc123"
+
+    async def _fake_get_public_key(requested_kid: str):
+        assert requested_kid == kid
+        return public_key
+
+    monkeypatch.setattr(ebay_webhooks, "_get_public_key", _fake_get_public_key)
+    # Reset caches between tests so a previous run can't leak.
+    monkeypatch.setattr(ebay_webhooks, "_public_keys", {})
+
+    return private_key, kid
+
+
+async def test_verify_signature_accepts_valid_signature(keypair_and_kid):
+    private_key, kid = keypair_and_kid
+    payload = b'{"notification": {"messageId": "abc", "text": "hi"}}'
+    header = _build_signed_envelope(payload, kid, private_key)
+
+    assert await ebay_webhooks.verify_signature(header, payload) is True
+
+
+async def test_verify_signature_rejects_tampered_payload(keypair_and_kid):
+    private_key, kid = keypair_and_kid
+    original_payload = b'{"price": 100}'
+    tampered_payload = b'{"price": 1}'  # buyer-induced price drop attempt
+    header = _build_signed_envelope(original_payload, kid, private_key)
+
+    assert await ebay_webhooks.verify_signature(header, tampered_payload) is False
+
+
+async def test_verify_signature_rejects_wrong_algorithm(keypair_and_kid):
+    private_key, kid = keypair_and_kid
+    payload = b"{}"
+    sha1 = hashlib.sha1(payload).digest()  # noqa: S324
+    signature = private_key.sign(sha1, ec.ECDSA(Prehashed(hashes.SHA1())))
+    bad_envelope = base64.b64encode(
+        json.dumps(
+            {
+                "alg": "RSA",  # wrong
+                "kid": kid,
+                "signature": base64.b64encode(signature).decode(),
+                "digest": "SHA1",
+            }
+        ).encode()
+    ).decode()
+
+    assert await ebay_webhooks.verify_signature(bad_envelope, payload) is False
+
+
+async def test_verify_signature_rejects_missing_header():
+    assert await ebay_webhooks.verify_signature(None, b"{}") is False
+    assert await ebay_webhooks.verify_signature("", b"{}") is False
+
+
+async def test_verify_signature_rejects_garbage_header():
+    # Not base64 / not JSON
+    assert await ebay_webhooks.verify_signature("@@@not-base64@@@", b"{}") is False
+
+
+def test_normalise_pem_inserts_linebreaks_into_single_line_pem():
+    body = "A" * 200  # 200 chars of body
+    single_line = f"-----BEGIN PUBLIC KEY----- {body} -----END PUBLIC KEY-----"
+    normalised = ebay_webhooks._normalise_pem(single_line)
+
+    assert normalised.startswith("-----BEGIN PUBLIC KEY-----\n")
+    assert normalised.endswith("\n-----END PUBLIC KEY-----")
+    body_lines = [
+        line for line in normalised.splitlines() if not line.startswith("-----")
+    ]
+    assert all(len(line) <= 64 for line in body_lines)
+    assert "".join(body_lines) == body
+
+
+def test_normalise_pem_passthrough_when_already_multiline():
+    pem = (
+        "-----BEGIN PUBLIC KEY-----\n"
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE\n"
+        "-----END PUBLIC KEY-----"
+    )
+    assert ebay_webhooks._normalise_pem(pem) == pem
+
+
+def test_validate_endpoint_challenge_matches_ebay_spec(monkeypatch):
+    """Order matters: SHA-256(challengeCode + verificationToken + endpoint)."""
+    from packages.config import settings as cfg
+
+    monkeypatch.setattr(cfg, "ebay_verification_token", "v" * 40)
+    monkeypatch.setattr(cfg, "ebay_webhook_endpoint", "https://example.test/ebay/webhook")
+
+    expected = hashlib.sha256(
+        b"abc123" + b"v" * 40 + b"https://example.test/ebay/webhook"
+    ).hexdigest()
+
+    assert ebay_webhooks.validate_endpoint_challenge("abc123") == expected


### PR DESCRIPTION
# Production-readiness: real ECDSA webhook signing + sale-confirmation test fix

Two changes that together unblock the eBay sandbox → production cutover.

## 1. Real `X-EBAY-SIGNATURE` validation

The previous handler accepted *any* non-empty signature header — fine for sandbox
testing but a hard security gap for production (anyone could POST forged buyer
messages to `/ebay/webhook` and trigger Agent 4 to send replies, accept offers,
or escalate to the seller). This PR replaces the stub with the real SHA1-with-ECDSA
verification per eBay's
[Notification API spec](https://developer.ebay.com/api-docs/commerce/notification/static/overview.html).

### How it works

1. eBay sends `X-EBAY-SIGNATURE` as base64-encoded JSON:

   ```json
   {
     "alg": "ECDSA",
     "kid": "<key-id>",
     "signature": "<base64>",
     "digest": "SHA1"
   }
   ```

2. We base64-decode the header, pull `kid` + `signature`.

3. Fetch the EC public key from:

   ```text
   GET /commerce/notification/v1/public_key/{kid}
   ```

   using a client-credentials app token. Cache the key for ~1 h per eBay's
   rate-limit guidance.

4. Verify SHA1-ECDSA over the **raw** HTTP body bytes.

Two in-process caches keep the hot path cheap:

- App token: cached until 60 s before its `expires_in`.
- Public key: cached per-`kid` for 1 h.

Both are protected by `asyncio.Lock` to avoid stampedes during burst traffic.

### Why we keep the `SKIP_WEBHOOK_HMAC` escape hatch

Local dev and CI don't have a real eBay-signed payload to feed in. The flag stays
so tests and curl-driven local repro keep working — but it's now the only
bypass, and the call site is:

```python
if settings.skip_webhook_hmac:
```

before the verifier, so leaving it on in prod is the only way to disable signing.

### `_normalise_pem` quirk

eBay's `getPublicKey` response sometimes returns PEM as one long line:

```text
-----BEGIN PUBLIC KEY----- AAA... -----END PUBLIC KEY-----
```

without internal `\n`s.

`cryptography.serialization.load_pem_public_key` rejects that.
`_normalise_pem` re-wraps the body at 64 chars when the input has no newlines
and passes through otherwise. Both forms are tested.

### What's tested

`tests/test_webhook_signature.py` (8 tests) generates a real `SECP256R1`
keypair, signs a payload locally, monkey-patches `_get_public_key` to return
the test public key, and exercises:

- Valid signature → accepted
- Tampered payload (e.g. price changed mid-flight) → rejected
- Wrong `alg` in envelope (`RSA` instead of `ECDSA`) → rejected
- Missing or empty header → rejected
- Garbage (non-base64) header → rejected
- `_normalise_pem` round-trip on both single- and multi-line PEMs
- `validate_endpoint_challenge` matches eBay's
  `SHA-256(challengeCode + verificationToken + endpoint)` ordering exactly

No mocked crypto — the round-trip is genuine end-to-end.

---

## 2. Fix flaky sale-confirmation + draft-approval tests

`tests/test_sale_confirmation.py::test_confirm_sale_*` and

```text
tests/test_conversations.py::test_approve_draft_endpoint
```

had been failing with:

```text
sqlalchemy.exc.InterfaceError: cannot perform operation: another operation in progress
```

That error blocked confidence in the sale code path — the very flow that turns
an `accept_offer` into real money — so it had to be rooted out before
production.

### Root cause

`pytest-asyncio` defaults to a fresh event loop per test. The app's async
engine is module-level (`packages/db/session.py:engine`), and `asyncpg` binds
each pooled connection to whichever event loop first reaches it. So:

- Test 1 grabs a connection, binds it to loop-1, runs successfully.
- Test 1 finishes, loop-1 closes, the connection goes back into the pool with
  half-cleaned state.
- Test 2 spins up loop-2, checks out the same connection, `asyncpg` sees
  `"another operation in progress"` because the connection's prior await
  never completed in the new loop's view.

That's why exactly one DB-touching test passed (the first one) and the rest
failed deterministically.

### Fix

One config change in `pyproject.toml`:

```toml
asyncio_default_fixture_loop_scope = "session"
asyncio_default_test_loop_scope = "session"
```

All tests now share one event loop for the whole pytest run. The engine's
connections stay loop-bound to the same loop their pool lives in, and the
`asyncpg` failure mode disappears.

No app code was touched — this was test infrastructure only.

---

## Files changed

| File | Change |
|---|---|
| `pyproject.toml` | `asyncio_default_*_loop_scope = "session"` |
| `packages/platform_adapters/ebay/webhooks.py` | New `verify_signature`, `_get_public_key`, `_get_app_token`, `_normalise_pem`; existing `validate_endpoint_challenge` rewritten to update incrementally rather than concat-then-encode |
| `apps/api/routers/webhooks.py` | `_validate_hmac` (stub) → `_validate_signature` (real, async); call site awaits |
| `tests/test_webhook_signature.py` | New — 8 tests covering the verifier end-to-end |

---

## Test plan

- `make migrate`
  - Local DB on `0011_phase5` revision (Phase 5 PR must merge first or be on this branch already).

- `make ci`
  - lint, format, mypy, full test suite all green.

- Run targeted tests:

  ```bash
  uv run pytest \
    tests/test_webhook_signature.py \
    tests/test_sale_confirmation.py \
    tests/test_conversations.py \
    -v
  ```

  The four previously-failing tests now pass; the eight new signature tests all pass.

- Sandbox smoke test before prod:
  - With sandbox creds, send a real eBay test notification through eBay's
    `testSubscription` endpoint and confirm it gets a `200` (not `401`) —
    proves the public-key fetch path works against eBay's actual API.

- Curl-driven local repro still works:

  ```bash
  SKIP_WEBHOOK_HMAC=true \
  curl -X POST .../ebay/webhook \
    -H "X-EBAY-SIGNATURE: anything" \
    -d '...'
  ```

  returns `200`.

---

## Production cutover checklist (separate operation, not in this PR)

1. Register a Production keyset in the eBay Developer Portal.
2. Set `EBAY_ENV=production`, swap `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET`
   to the production values.
3. Update `EBAY_WEBHOOK_ENDPOINT` to the prod domain and
   `EBAY_VERIFICATION_TOKEN` to a fresh 32+ char secret.
4. Re-run eBay's GET-challenge endpoint validation against the prod URL.
5. Leave one or two sellers on `autonomy_level=draft` for a week to
   spot-check Agent 4's drafts before promoting any seller to
   `auto_low_risk`.
6. Verify in-process caches behave:
   - First request after deploy will incur one app-token + one public-key fetch (~200 ms).
   - Subsequent requests are pure CPU.

---

## Out of scope (deferred)

- Persistent public-key cache (Redis or DB).
  - The in-process cache is per-API-instance — fine for our single-EC2 topology,
    but if/when we scale horizontally, the cache miss rate grows linearly with
    instance count and may push us toward eBay's rate limits.

- Trading-API-only listings still can't be repriced
  - Deferred from Phase 5, unrelated here.