### PR TITLE
feat: serve eBay listing images from public S3 instead of internal MinIO URL

### DIFF
--- a/infrastructure/s3-images-setup.md
+++ b/infrastructure/s3-images-setup.md
@@ -1,0 +1,124 @@
+# S3 image hosting setup
+
+eBay's Inventory and Trading APIs fetch listing images from a public URL. The
+internal MinIO endpoint (`http://minio:9000/...`) is not reachable from eBay,
+so production must serve images from a public S3 bucket.
+
+## One-time provisioning
+
+Replace `salesrep-images-prod` with whatever bucket name you want. Bucket names
+are globally unique, so pick something namespaced. The eBay seller account is
+UK-based, so the bucket lives in `eu-west-2` for latency.
+
+```bash
+BUCKET=salesrep-images-prod
+REGION=eu-west-2
+
+# 1. Create the bucket
+aws s3api create-bucket \
+  --bucket "$BUCKET" \
+  --region "$REGION" \
+  --create-bucket-configuration "LocationConstraint=$REGION"
+
+# 2. Allow public policies (S3 blocks public access by default since 2023)
+aws s3api put-public-access-block \
+  --bucket "$BUCKET" \
+  --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+# 3. Attach a public-read bucket policy (GetObject only)
+cat > /tmp/bucket-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadGetObject",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::$BUCKET/*"
+    }
+  ]
+}
+EOF
+aws s3api put-bucket-policy --bucket "$BUCKET" --policy file:///tmp/bucket-policy.json
+
+# 4. (Optional) CORS, so the web app can fetch directly without a proxy
+cat > /tmp/cors.json <<EOF
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["https://devopslearn.store", "http://localhost:3000"],
+      "AllowedMethods": ["GET"],
+      "AllowedHeaders": ["*"],
+      "MaxAgeSeconds": 3000
+    }
+  ]
+}
+EOF
+aws s3api put-bucket-cors --bucket "$BUCKET" --cors-configuration file:///tmp/cors.json
+```
+
+## IAM permission for the EC2 instance role
+
+The EC2 host's instance role needs `s3:PutObject` (and `s3:HeadBucket`) on the
+new bucket. Attach this inline policy to the role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:HeadBucket"],
+      "Resource": [
+        "arn:aws:s3:::salesrep-images-prod",
+        "arn:aws:s3:::salesrep-images-prod/*"
+      ]
+    }
+  ]
+}
+```
+
+## Production env vars
+
+Set these on the EC2 host (or in SSM Parameter Store, or wherever the prod
+`.env` lives — **not** in the repo):
+
+```bash
+# Leave empty so boto3 hits real AWS S3 (don't point at MinIO)
+S3_ENDPOINT_URL=
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_BUCKET=salesrep-images-prod
+S3_REGION=eu-west-2
+# The host eBay (and buyers) will fetch images from:
+S3_PUBLIC_BASE_URL=https://salesrep-images-prod.s3.eu-west-2.amazonaws.com
+```
+
+Leaving `S3_ACCESS_KEY` / `S3_SECRET_KEY` empty causes boto3 to pick up the
+EC2 instance role automatically — preferred over baking long-lived keys into
+the env file.
+
+## Local dev (unchanged)
+
+Local `.env` still uses MinIO. Leave `S3_PUBLIC_BASE_URL` empty and image URLs
+fall back to `${S3_ENDPOINT_URL}/${S3_BUCKET}/{key}` (i.e. MinIO). eBay calls
+won't work locally — that's expected; image hosting only matters for prod
+publishes.
+
+## Verifying
+
+After deploying:
+
+```bash
+# Upload a tiny test object, confirm it's publicly fetchable
+echo hello > /tmp/test.txt
+aws s3 cp /tmp/test.txt "s3://$BUCKET/test.txt"
+curl -I "https://$BUCKET.s3.$REGION.amazonaws.com/test.txt"
+# Expect HTTP/1.1 200 OK
+aws s3 rm "s3://$BUCKET/test.txt"
+```
+
+Then publish an item through the app and check that the `eBay create_inventory_item`
+log line shows a `https://...amazonaws.com/...` URL (not `http://minio:...`).

--- a/packages/config.py
+++ b/packages/config.py
@@ -34,11 +34,17 @@ class Settings(BaseSettings):
     aws_region: str = "eu-west-2"
 
     # AWS S3 (for storing item images)
+    # Leave s3_endpoint_url empty in prod so boto3 hits real AWS S3.
+    # s3_public_base_url is the externally reachable URL base eBay (and buyers)
+    # will hit — e.g. https://salesrep-images.s3.eu-west-2.amazonaws.com
+    # or a CloudFront domain. If empty, falls back to {s3_endpoint_url}/{bucket},
+    # which is correct for local MinIO only.
     s3_endpoint_url: str = "http://localhost:9000"
     s3_access_key: str = "minioadmin"
     s3_secret_key: str = "minioadmin"
     s3_bucket: str = "salesrep-images"
     s3_region: str = "us-east-1"
+    s3_public_base_url: str = ""
 
     openai_api_key: str = ""
     openai_base_url: str = ""

--- a/packages/storage.py
+++ b/packages/storage.py
@@ -28,32 +28,38 @@ _CONTENT_TYPES = {
 
 def _client():
     """
-    Create and return a boto3 S3 client configured for MinIO/S3.
+    Create and return a boto3 S3 client.
 
-    Uses settings for endpoint, credentials, and region with S3v4 signatures.
+    If s3_endpoint_url is set, points at MinIO (local dev). If empty, boto3
+    hits real AWS S3 using the configured region and IAM creds (EC2 role in
+    prod, env-var creds elsewhere).
     """
-    return boto3.client(
-        "s3",
-        endpoint_url=settings.s3_endpoint_url,
-        aws_access_key_id=settings.s3_access_key,
-        aws_secret_access_key=settings.s3_secret_key,
-        region_name=settings.s3_region,
-        config=Config(signature_version="s3v4"),
-    )
+    kwargs: dict[str, Any] = {
+        "region_name": settings.s3_region,
+        "config": Config(signature_version="s3v4"),
+    }
+    if settings.s3_endpoint_url:
+        kwargs["endpoint_url"] = settings.s3_endpoint_url
+    if settings.s3_access_key and settings.s3_secret_key:
+        kwargs["aws_access_key_id"] = settings.s3_access_key
+        kwargs["aws_secret_access_key"] = settings.s3_secret_key
+    return boto3.client("s3", **kwargs)
 
 
 def _ensure_bucket(client: Any) -> None:
     """
     Ensure the S3 bucket exists, creating it if necessary.
 
-    Checks if the bucket exists and creates it if not found.
+    Only auto-creates against MinIO (s3_endpoint_url set). On real AWS the
+    bucket is provisioned out-of-band — see infrastructure/s3-images-setup.md.
     """
     try:
-        # Check if bucket exists
         client.head_bucket(Bucket=settings.s3_bucket)
     except ClientError:
-        # Create bucket if it doesn't exist
-        client.create_bucket(Bucket=settings.s3_bucket)
+        if settings.s3_endpoint_url:
+            client.create_bucket(Bucket=settings.s3_bucket)
+        else:
+            raise
 
 
 async def upload_image(
@@ -83,6 +89,9 @@ async def upload_image(
 
     # Run upload in thread pool to avoid blocking
     await asyncio.to_thread(_upload)
-    # Generate public URL for the uploaded image
-    url = f"{settings.s3_endpoint_url}/{settings.s3_bucket}/{key}"
+    # Prefer the explicit public base URL (real S3 / CloudFront). Fall back to
+    # the endpoint URL for local MinIO — eBay cannot reach that, so prod must
+    # always set s3_public_base_url.
+    base = settings.s3_public_base_url or f"{settings.s3_endpoint_url}/{settings.s3_bucket}"
+    url = f"{base.rstrip('/')}/{key}"
     return key, url


### PR DESCRIPTION
## Summary

- eBay's Inventory/Trading APIs fetch image URLs server-side. Prod was passing them `http://minio:9000/...`, the internal docker hostname, which eBay can't resolve — it surfaced as a generic `errorId: 25001` _"Core Inventory Service internal error"_ and blocked all publishes.
- Adds `s3_public_base_url` setting so the URL returned by `upload_image` can be decoupled from the storage endpoint. In prod we point this at a public S3 (or CloudFront) URL; locally it stays empty and falls back to MinIO behaviour.
- Loosens `_client` / `_ensure_bucket` so boto3 hits real AWS S3 (and uses the EC2 instance role) whenever `S3_ENDPOINT_URL` is unset, instead of always forcing the MinIO endpoint.
- Ships `infrastructure/s3-images-setup.md` with the `aws s3api` commands to create the bucket, disable the public-access-block, attach a public-read GetObject policy, set CORS, the required EC2 IAM policy, and the prod env vars.

## Why now

Production listings have been failing with `25001` since the EC2 host was switched to the production eBay environment — the misleading error message buried the real cause (unreachable image URL).

## Test plan

- [ ] Run the AWS CLI commands in `infrastructure/s3-images-setup.md` to provision `salesrep-images-prod` in `eu-west-2`.
- [ ] Attach the IAM policy to the EC2 instance role.
- [ ] Set prod env: `S3_ENDPOINT_URL=` (empty), `S3_BUCKET=salesrep-images-prod`, `S3_REGION=eu-west-2`, `S3_PUBLIC_BASE_URL=https://salesrep-images-prod.s3.eu-west-2.amazonaws.com`.
- [ ] Deploy and publish a test listing through the app.
- [ ] Confirm the `Image URL prepared for eBay` log line shows an `amazonaws.com` URL, the `PUT /sell/inventory/v1/inventory_item/...` call returns 200/204, and the listing appears live on eBay.
- [ ] Verify local dev `make up` still uploads to MinIO unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)