### PR TITLE
feat: subscribe sellers to eBay buyer-message notifications via Trading API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help up down logs ps install install-ml install-nlp test evals evals-sync fmt lint mypy ci migrate migration shell-api shell-db worker
+.PHONY: help up down logs ps install install-ml install-nlp test evals evals-sync fmt lint mypy ci migrate migration shell-api shell-db worker subscribe-messages
 
 help:
 	@echo "Stack:"
@@ -87,3 +87,10 @@ shell-api:
 
 shell-db:
 	docker compose exec postgres psql -U $${POSTGRES_USER:-salesrep} -d $${POSTGRES_DB:-salesrep}
+
+# Backfill: subscribe every existing eBay-connected seller to buyer-message
+# notifications (Trading API SetNotificationPreferences). New sellers are
+# auto-subscribed on OAuth callback — only re-run for sellers connected
+# before this wiring landed.
+subscribe-messages:
+	docker compose exec api uv run python -m packages.platform_adapters.ebay.subscribe_cli

--- a/apps/api/routers/ebay.py
+++ b/apps/api/routers/ebay.py
@@ -14,6 +14,7 @@ from packages.config import settings
 from packages.crypto import encrypt_token
 from packages.db.models import EbayOAuthState, Platform, PlatformCredential, Seller
 from packages.db.session import get_session
+from packages.platform_adapters.ebay.notifications import subscribe_messages
 from packages.platform_adapters.ebay.oauth import (
     build_authorization_url,
     exchange_code,
@@ -133,6 +134,22 @@ async def ebay_callback(
     await session.commit()
 
     logger.info("eBay OAuth tokens saved for seller %s", seller_id)
+
+    # Auto-subscribe the seller to buyer-message notifications. The
+    # application-level destination is configured once in the eBay Developer
+    # Portal; this call wires the per-user event preferences. Failures are
+    # logged but don't block OAuth — the seller can still list/browse, and
+    # we can backfill via scripts/subscribe_existing_sellers.py.
+    try:
+        subscribed = await subscribe_messages(access_token)
+        if not subscribed:
+            logger.warning(
+                "Failed to subscribe seller %s to eBay notifications — buyer "
+                "messages will not arrive until backfilled",
+                seller_id,
+            )
+    except Exception:
+        logger.exception("subscribe_messages raised for seller %s", seller_id)
 
     # Redirect back to the frontend chat page with success indicator
     return RedirectResponse(url=f"{_frontend_chat()}?ebay=connected", status_code=302)

--- a/packages/platform_adapters/ebay/notifications.py
+++ b/packages/platform_adapters/ebay/notifications.py
@@ -1,0 +1,146 @@
+"""eBay Trading API — per-user notification subscription.
+
+The Developer Portal only sets up the *application-level destination* (where
+eBay should POST events). Choosing which events to send for a given seller is
+a per-user-token operation done via the Trading API call
+`SetNotificationPreferences`.
+
+This module exposes `subscribe_messages(token, marketplace_id)` which enables
+the buyer-message events used by Agent 4 (comms):
+
+  - MyMessageseBayMessage  — buyer messages via "Contact seller"
+  - MyMessagesM2MMessage   — member-to-member messages
+  - AskSellerQuestion      — legacy "Ask seller a question" form
+
+Call once per seller after OAuth. Idempotent — calling again with the same
+event list is a no-op as far as eBay is concerned.
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+
+import httpx
+
+from packages.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+_API_BASE = {
+    "sandbox": "https://api.sandbox.ebay.com",
+    "production": "https://api.ebay.com",
+}
+
+# Trading API site IDs (X-EBAY-API-SITEID header)
+_SITE_ID_MAP = {
+    "EBAY_US": "0",
+    "EBAY_GB": "3",
+    "EBAY_AU": "15",
+    "EBAY_DE": "77",
+    "EBAY_FR": "71",
+}
+
+# Notification events the comms agent depends on.
+_BUYER_MESSAGE_EVENTS = (
+    "MyMessageseBayMessage",
+    "MyMessagesM2MMessage",
+    "AskSellerQuestion",
+)
+
+
+def _base() -> str:
+    return _API_BASE.get(settings.ebay_env, _API_BASE["production"])
+
+
+def _site_id(marketplace_id: str) -> str:
+    return _SITE_ID_MAP.get(marketplace_id, "3")
+
+
+def _build_request_xml(events: tuple[str, ...]) -> str:
+    enables = "".join(
+        f"<NotificationEnable>"
+        f"<EventType>{event}</EventType>"
+        f"<EventEnable>Enable</EventEnable>"
+        f"</NotificationEnable>"
+        for event in events
+    )
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<SetNotificationPreferencesRequest xmlns="urn:ebay:apis:eBLBaseComponents">'
+        "<ApplicationDeliveryPreferences>"
+        "<ApplicationEnable>Enable</ApplicationEnable>"
+        "</ApplicationDeliveryPreferences>"
+        f"<UserDeliveryPreferenceArray>{enables}</UserDeliveryPreferenceArray>"
+        "</SetNotificationPreferencesRequest>"
+    )
+
+
+async def subscribe_messages(
+    access_token: str,
+    *,
+    marketplace_id: str | None = None,
+    events: tuple[str, ...] = _BUYER_MESSAGE_EVENTS,
+) -> bool:
+    """Subscribe a seller's user-token to buyer-message notifications.
+
+    Returns True on `Ack=Success` or `Ack=Warning`, False otherwise. Network
+    or HTTP errors are caught and logged so the caller (the OAuth callback)
+    can ignore subscription failures rather than abort the whole flow.
+    """
+    marketplace_id = marketplace_id or settings.ebay_marketplace_id
+    site_id = _site_id(marketplace_id)
+    body = _build_request_xml(events)
+
+    headers = {
+        "X-EBAY-API-SITEID": site_id,
+        "X-EBAY-API-COMPATIBILITY-LEVEL": "1173",
+        "X-EBAY-API-CALL-NAME": "SetNotificationPreferences",
+        "X-EBAY-API-IAF-TOKEN": access_token,
+        "Content-Type": "text/xml;charset=utf-8",
+    }
+    url = f"{_base()}/ws/api.dll"
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            r = await client.post(url, headers=headers, content=body.encode("utf-8"))
+    except httpx.HTTPError:
+        logger.exception("subscribe_messages: HTTP error calling Trading API")
+        return False
+
+    if r.status_code != 200:
+        logger.error(
+            "subscribe_messages: Trading API returned %s — %s",
+            r.status_code,
+            r.text[:500],
+        )
+        return False
+
+    try:
+        root = ET.fromstring(r.text)
+    except ET.ParseError:
+        logger.error("subscribe_messages: response was not valid XML — %s", r.text[:500])
+        return False
+
+    ns = {"ebay": "urn:ebay:apis:eBLBaseComponents"}
+    ack = root.findtext("ebay:Ack", namespaces=ns)
+    if ack not in ("Success", "Warning"):
+        errors = [
+            (
+                e.findtext("ebay:LongMessage", namespaces=ns)
+                or e.findtext("ebay:ShortMessage", namespaces=ns)
+                or "?"
+            )
+            for e in root.findall("ebay:Errors", namespaces=ns)
+        ]
+        logger.error("subscribe_messages: Ack=%s — %s", ack, "; ".join(errors))
+        return False
+
+    logger.info(
+        "subscribe_messages: subscribed to %s on site %s (Ack=%s)",
+        ",".join(events),
+        site_id,
+        ack,
+    )
+    return True

--- a/packages/platform_adapters/ebay/subscribe_cli.py
+++ b/packages/platform_adapters/ebay/subscribe_cli.py
@@ -1,0 +1,67 @@
+"""Backfill CLI — subscribe every existing eBay-connected seller to
+buyer-message notifications via Trading API SetNotificationPreferences.
+
+The OAuth callback handles new sellers automatically. This is for sellers
+who connected before that wiring landed.
+
+Run via:
+    make subscribe-messages
+or directly:
+    docker compose exec api uv run python -m packages.platform_adapters.ebay.subscribe_cli
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy import select
+
+from packages.db.models import Platform, PlatformCredential
+from packages.db.session import SessionLocal
+from packages.platform_adapters.ebay.notifications import subscribe_messages
+from packages.platform_adapters.ebay.sell import get_seller_token
+
+logger = logging.getLogger(__name__)
+
+
+async def _run() -> None:
+    async with SessionLocal() as session:
+        creds = (
+            await session.scalars(
+                select(PlatformCredential).where(PlatformCredential.platform == Platform.ebay)
+            )
+        ).all()
+        logger.info("found %d eBay credentials", len(creds))
+
+        ok = failed = 0
+        for cred in creds:
+            try:
+                token = await get_seller_token(cred.seller_id, session)
+            except Exception:
+                logger.exception("could not load token for seller %s", cred.seller_id)
+                failed += 1
+                continue
+
+            if await subscribe_messages(token.access_token):
+                ok += 1
+                logger.info("subscribed seller %s", cred.seller_id)
+            else:
+                failed += 1
+                logger.warning("subscribe failed for seller %s", cred.seller_id)
+
+        # commit any token refreshes get_seller_token may have written
+        await session.commit()
+        logger.info("done — ok=%d failed=%d", ok, failed)
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ebay_notification_subscribe.py
+++ b/tests/test_ebay_notification_subscribe.py
@@ -1,0 +1,129 @@
+"""Tests for packages.platform_adapters.ebay.notifications.subscribe_messages.
+
+Mocks Trading API with respx to verify the request shape and the parsing of
+Success / Warning / Failure / non-200 / malformed-XML / network-error paths.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from packages.platform_adapters.ebay import notifications
+from packages.platform_adapters.ebay.notifications import subscribe_messages
+
+
+@pytest.fixture(autouse=True)
+def _patch_settings(monkeypatch):
+    monkeypatch.setattr(
+        notifications,
+        "settings",
+        type(
+            "FakeSettings",
+            (),
+            {"ebay_env": "production", "ebay_marketplace_id": "EBAY_GB"},
+        )(),
+    )
+
+
+_SUCCESS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<SetNotificationPreferencesResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+  <Ack>Success</Ack>
+</SetNotificationPreferencesResponse>"""
+
+_WARNING_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<SetNotificationPreferencesResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+  <Ack>Warning</Ack>
+  <Errors>
+    <ShortMessage>Some warning</ShortMessage>
+    <SeverityCode>Warning</SeverityCode>
+  </Errors>
+</SetNotificationPreferencesResponse>"""
+
+_FAILURE_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<SetNotificationPreferencesResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+  <Ack>Failure</Ack>
+  <Errors>
+    <ShortMessage>Invalid token</ShortMessage>
+    <LongMessage>The auth token is invalid.</LongMessage>
+  </Errors>
+</SetNotificationPreferencesResponse>"""
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_success_sends_correct_request():
+    route = respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(200, text=_SUCCESS_XML)
+    )
+
+    ok = await subscribe_messages("test_token")
+
+    assert ok is True
+    assert route.called
+
+    req = route.calls[0].request
+    body = req.content.decode("utf-8")
+    assert "SetNotificationPreferencesRequest" in body
+    assert "<ApplicationEnable>Enable</ApplicationEnable>" in body
+    assert "MyMessageseBayMessage" in body
+    assert "MyMessagesM2MMessage" in body
+    assert "AskSellerQuestion" in body
+
+    assert req.headers["X-EBAY-API-CALL-NAME"] == "SetNotificationPreferences"
+    assert req.headers["X-EBAY-API-IAF-TOKEN"] == "test_token"
+    assert req.headers["X-EBAY-API-SITEID"] == "3"  # EBAY_GB
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_treats_warning_as_success():
+    respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(200, text=_WARNING_XML)
+    )
+    assert await subscribe_messages("test_token") is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_failure_returns_false():
+    respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(200, text=_FAILURE_XML)
+    )
+    assert await subscribe_messages("test_token") is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_non_200_returns_false():
+    respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    assert await subscribe_messages("test_token") is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_invalid_xml_returns_false():
+    respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(200, text="not xml")
+    )
+    assert await subscribe_messages("test_token") is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_network_error_returns_false():
+    respx.post("https://api.ebay.com/ws/api.dll").mock(side_effect=httpx.ConnectError("nope"))
+    assert await subscribe_messages("test_token") is False
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_subscribe_messages_uses_marketplace_override():
+    route = respx.post("https://api.ebay.com/ws/api.dll").mock(
+        return_value=httpx.Response(200, text=_SUCCESS_XML)
+    )
+    await subscribe_messages("test_token", marketplace_id="EBAY_US")
+    assert route.calls[0].request.headers["X-EBAY-API-SITEID"] == "0"


### PR DESCRIPTION
## Summary

Buyer messages aren't reaching our webhook. Cause: the eBay Developer Portal only configures the **application-level destination** (where to POST). The actual *per-event* subscription is per-user-token and has to be made via Trading API `SetNotificationPreferences`. Until that runs for a seller, eBay won't push any buyer messages for them — even with a validated destination.

This PR wires that call into:

- **`packages/platform_adapters/ebay/notifications.py`** — `subscribe_messages(token, marketplace_id?)` posts a `SetNotificationPreferences` SOAP request enabling `MyMessageseBayMessage`, `MyMessagesM2MMessage`, and `AskSellerQuestion`. Returns True/False; network/parse/Failure-Ack errors are caught and logged.
- **`apps/api/routers/ebay.py`** — OAuth callback now auto-subscribes new sellers after token storage. Wrapped in try/except so a subscription failure never breaks the OAuth flow.
- **`packages/platform_adapters/ebay/subscribe_cli.py` + `make subscribe-messages`** — one-shot backfill that iterates `PlatformCredential` rows and subscribes each existing seller. Idempotent.
- **`tests/test_ebay_notification_subscribe.py`** — 7 cases (Success, Warning, Failure, non-200, malformed XML, network error, marketplace override).

## ⚠️ Known limitation — handler still 401s legacy notifications

Platform Notifications arrive as **SOAP envelopes without `X-EBAY-SIGNATURE`** — auth is via embedded IAF token + dev/cert/app-name headers. The current `apps/api/routers/webhooks.py:_validate_signature` only knows the new ECDSA format and will 401 them.

To validate end-to-end after this merges:

1. Run `make subscribe-messages` (or just re-OAuth) for the test seller.
2. On the EC2 host, temporarily set `SKIP_WEBHOOK_HMAC=true` and `docker compose up -d --force-recreate api`.
3. Send a buyer message to a live listing.
4. Confirm the SOAP body lands in the logs.
5. **Turn `SKIP_WEBHOOK_HMAC` back off** — leaving signature verification disabled is unsafe.

A follow-up PR will add a SOAP-aware branch to the webhook router.

## Test plan

- [x] `pytest tests/test_ebay_notification_subscribe.py` — 7 passed
- [x] `pytest tests/ --ignore=tests/evals/` — 103 passed (no regressions)
- [x] `ruff format` / `ruff check` / `mypy` clean on the touched files
- [ ] After merge: redeploy, run `make subscribe-messages` on prod, then verify with `SKIP_WEBHOOK_HMAC=true` + buyer-message send

🤖 Generated with [Claude Code](https://claude.com/claude-code)