### PR TITLE
feat: finish Phase 5 — autonomy UI, reprice history, edit-rate, LLM regression suite

### DIFF
--- a/alembic/versions/0012_phase5_reprice_events_and_edit_flag.py
+++ b/alembic/versions/0012_phase5_reprice_events_and_edit_flag.py
@@ -1,0 +1,66 @@
+"""phase 5 reprice_events + buyer_messages.seller_edited
+
+Adds the per-event reprice history table populated by
+packages/agents/pricing/reprice.py, and the seller_edited flag on
+buyer_messages used to surface the seller draft edit rate.
+
+Revision ID: 0012_phase5b
+Revises: 0011_phase5
+Create Date: 2026-05-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0012_phase5b"
+down_revision: str | None = "0011_phase5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reprice_events",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "listing_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("listings.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "seller_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sellers.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("old_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("new_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column(
+            "repriced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_reprice_events_seller_repriced_at",
+        "reprice_events",
+        ["seller_id", "repriced_at"],
+    )
+
+    op.add_column(
+        "buyer_messages",
+        sa.Column("seller_edited", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("buyer_messages", "seller_edited")
+    op.drop_index("ix_reprice_events_seller_repriced_at", table_name="reprice_events")
+    op.drop_table("reprice_events")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -11,9 +11,11 @@ from apps.api.routers import (
     images,
     intake,
     internal,
+    listings,
     pages,
     webhooks,
 )
+from apps.api.routers import settings as settings_router
 from packages.config import configure_tracing, settings
 
 # Surface app loggers (pricing/publisher/intake) at INFO so Round/Browse/etc.
@@ -57,5 +59,7 @@ app.include_router(intake.router)  # Handles the "Chat" and Image uploads
 app.include_router(conversations.router)  # Handles the draft approval inbox
 app.include_router(images.router)  # Handles image storage/retrieval
 app.include_router(internal.router)  # Backend administrative tools
+app.include_router(listings.router)  # Listing-level endpoints (reprice history)
+app.include_router(settings_router.router)  # Seller autonomy + stale-reprice settings
 app.include_router(pages.router)  # Serves the static Frontend Files (Next.js Build)
 app.include_router(webhooks.router)  # Listens for eBay Events

--- a/apps/api/routers/conversations.py
+++ b/apps/api/routers/conversations.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -115,6 +115,7 @@ async def approve_draft(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)) from e
 
     buyer_message.requires_approval = False
+    buyer_message.seller_edited = False
     buyer_message.processed_at = datetime.now(UTC)
     await session.commit()
 
@@ -135,7 +136,9 @@ async def edit_draft(
 
     buyer_message, recipient_id, item_id = await _load_reply_context(message_id, seller.id, session)
 
+    original = buyer_message.draft_reply or ""
     buyer_message.draft_reply = body.text
+    buyer_message.seller_edited = body.text.strip() != original.strip()
 
     try:
         await send_message(
@@ -172,6 +175,53 @@ async def dismiss_draft(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Message not found")
 
     buyer_message.requires_approval = False
+    buyer_message.seller_edited = False
     await session.commit()
 
     return {"status": "dismissed"}
+
+
+@router.get("/stats")
+async def get_draft_stats(
+    seller: Seller = Depends(get_current_seller),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, int | float]:
+    """Aggregate draft outcomes — used by the settings page to surface the edit rate.
+
+    - `pending`: drafts awaiting seller action
+    - `approved`: drafts sent as-is (seller_edited = False)
+    - `edited`: drafts the seller changed before sending (seller_edited = True)
+    - `edit_rate`: edited / (approved + edited), 0 when there are no resolved drafts
+    """
+    pending_expr = case(
+        (BuyerMessage.requires_approval.is_(True), 1),
+        else_=0,
+    )
+    approved_expr = case(
+        (BuyerMessage.seller_edited.is_(False), 1),
+        else_=0,
+    )
+    edited_expr = case(
+        (BuyerMessage.seller_edited.is_(True), 1),
+        else_=0,
+    )
+
+    stmt = select(
+        func.coalesce(func.sum(pending_expr), 0),
+        func.coalesce(func.sum(approved_expr), 0),
+        func.coalesce(func.sum(edited_expr), 0),
+    ).where(
+        BuyerMessage.seller_id == seller.id,
+        BuyerMessage.draft_reply.is_not(None),
+    )
+    pending, approved, edited = (await session.execute(stmt)).one()
+
+    resolved = int(approved) + int(edited)
+    edit_rate = float(edited) / resolved if resolved else 0.0
+
+    return {
+        "pending": int(pending),
+        "approved": int(approved),
+        "edited": int(edited),
+        "edit_rate": round(edit_rate, 3),
+    }

--- a/apps/api/routers/listings.py
+++ b/apps/api/routers/listings.py
@@ -1,0 +1,46 @@
+"""Listing-level endpoints — currently just reprice history (Phase 5)."""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from apps.api.deps import get_current_seller
+from packages.db.models import Item, Listing, RepriceEvent, Seller
+from packages.db.session import get_session
+
+router = APIRouter(prefix="/listings", tags=["listings"])
+
+
+@router.get("/reprice-history")
+async def get_reprice_history(
+    limit: int = Query(50, ge=1, le=200),
+    seller: Seller = Depends(get_current_seller),
+    session: AsyncSession = Depends(get_session),
+) -> list[dict[str, Any]]:
+    """Return the seller's most recent automatic-reprice events."""
+    stmt = (
+        select(RepriceEvent, Listing, Item)
+        .join(Listing, Listing.id == RepriceEvent.listing_id)
+        .join(Item, Item.id == Listing.item_id)
+        .options(joinedload(RepriceEvent.listing))
+        .where(RepriceEvent.seller_id == seller.id)
+        .order_by(RepriceEvent.repriced_at.desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+
+    return [
+        {
+            "id": str(event.id),
+            "listing_id": str(event.listing_id),
+            "item_name": item.name,
+            "listing_url": listing.url,
+            "old_price": float(event.old_price),
+            "new_price": float(event.new_price),
+            "repriced_at": event.repriced_at.isoformat(),
+        }
+        for event, listing, item in rows
+    ]

--- a/apps/api/routers/settings.py
+++ b/apps/api/routers/settings.py
@@ -16,6 +16,11 @@ from apps.api.deps import get_current_seller
 from packages.db.models import AutonomyLevel, Seller
 from packages.db.session import get_session
 
+# get_current_seller and get_session may return objects from different
+# SQLAlchemy sessions when dependencies are overridden in tests. In production
+# they share a session, but the handlers below stay robust by re-fetching the
+# Seller through the request session before mutating it.
+
 router = APIRouter(prefix="/settings", tags=["settings"])
 
 
@@ -60,19 +65,28 @@ async def update_seller_settings(
     seller: Seller = Depends(get_current_seller),
     session: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
-    if body.autonomy_level is None and body.stale_threshold_days is None and body.max_reprice_count is None:
+    if (
+        body.autonomy_level is None
+        and body.stale_threshold_days is None
+        and body.max_reprice_count is None
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No settings provided",
         )
 
+    # Re-fetch into the request session so commit() actually persists.
+    db_seller = await session.get(Seller, seller.id)
+    if db_seller is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Seller not found")
+
     if body.autonomy_level is not None:
-        seller.autonomy_level = body.autonomy_level
+        db_seller.autonomy_level = body.autonomy_level
     if body.stale_threshold_days is not None:
-        seller.stale_threshold_days = body.stale_threshold_days
+        db_seller.stale_threshold_days = body.stale_threshold_days
     if body.max_reprice_count is not None:
-        seller.max_reprice_count = body.max_reprice_count
+        db_seller.max_reprice_count = body.max_reprice_count
 
     await session.commit()
-    await session.refresh(seller)
-    return _serialise(seller)
+    await session.refresh(db_seller)
+    return _serialise(db_seller)

--- a/apps/api/routers/settings.py
+++ b/apps/api/routers/settings.py
@@ -1,0 +1,78 @@
+"""Seller-facing settings — Phase 5 autonomy + stale-reprice controls.
+
+The fields exposed here are read by the comms graph
+(`_resolve_requires_approval`) and the stale-reprice query in
+`/internal/check-stale-listings`. Default values are set at the DB level
+(see migration 0011_phase5).
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api.deps import get_current_seller
+from packages.db.models import AutonomyLevel, Seller
+from packages.db.session import get_session
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+# Outer bounds the UI / API will accept. Stale threshold below 1 day would
+# trigger reprice on day-of-listing; above 90 stops the feature being useful.
+_MIN_STALE_DAYS = 1
+_MAX_STALE_DAYS = 90
+_MIN_REPRICE = 0
+_MAX_REPRICE = 10
+
+
+class SellerSettings(BaseModel):
+    autonomy_level: AutonomyLevel
+    stale_threshold_days: int = Field(ge=_MIN_STALE_DAYS, le=_MAX_STALE_DAYS)
+    max_reprice_count: int = Field(ge=_MIN_REPRICE, le=_MAX_REPRICE)
+
+
+class SellerSettingsPatch(BaseModel):
+    autonomy_level: AutonomyLevel | None = None
+    stale_threshold_days: int | None = Field(default=None, ge=_MIN_STALE_DAYS, le=_MAX_STALE_DAYS)
+    max_reprice_count: int | None = Field(default=None, ge=_MIN_REPRICE, le=_MAX_REPRICE)
+
+
+def _serialise(seller: Seller) -> dict[str, Any]:
+    return {
+        "autonomy_level": seller.autonomy_level.value,
+        "stale_threshold_days": seller.stale_threshold_days,
+        "max_reprice_count": seller.max_reprice_count,
+    }
+
+
+@router.get("/seller")
+async def get_seller_settings(
+    seller: Seller = Depends(get_current_seller),
+) -> dict[str, Any]:
+    return _serialise(seller)
+
+
+@router.patch("/seller")
+async def update_seller_settings(
+    body: SellerSettingsPatch,
+    seller: Seller = Depends(get_current_seller),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, Any]:
+    if body.autonomy_level is None and body.stale_threshold_days is None and body.max_reprice_count is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No settings provided",
+        )
+
+    if body.autonomy_level is not None:
+        seller.autonomy_level = body.autonomy_level
+    if body.stale_threshold_days is not None:
+        seller.stale_threshold_days = body.stale_threshold_days
+    if body.max_reprice_count is not None:
+        seller.max_reprice_count = body.max_reprice_count
+
+    await session.commit()
+    await session.refresh(seller)
+    return _serialise(seller)

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -462,6 +462,12 @@ function ChatPageInner() {
           >
             Inbox
           </Link>
+          <Link
+            href="/settings"
+            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
+          >
+            Settings
+          </Link>
         </nav>
 
         <div className="flex-1" />

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -176,6 +176,12 @@ export default function InboxPage() {
               </span>
             )}
           </Link>
+          <Link
+            href="/settings"
+            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
+          >
+            Settings
+          </Link>
         </nav>
 
         <div className="flex-1" />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  api,
+  AutonomyLevel,
+  DraftStats,
+  RepriceEvent,
+  SellerSettings,
+} from "@/lib/api";
+
+const AUTONOMY_OPTIONS: {
+  value: AutonomyLevel;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "draft",
+    label: "Draft mode",
+    description: "Every reply is queued for your approval. Safest default.",
+  },
+  {
+    value: "auto_low_risk",
+    label: "Auto low-risk",
+    description:
+      "Auto-send factual answers and polite declines. Counter-offers, accepts, and escalations still need approval.",
+  },
+  {
+    value: "full_auto",
+    label: "Full auto",
+    description:
+      "Auto-send all replies except accepting an offer or escalating to you. Use with care.",
+  },
+];
+
+function formatGBP(amount: number) {
+  return `£${amount.toFixed(2)}`;
+}
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString();
+}
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const [settings, setSettings] = useState<SellerSettings | null>(null);
+  const [stats, setStats] = useState<DraftStats | null>(null);
+  const [reprices, setReprices] = useState<RepriceEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [s, stat, hist] = await Promise.all([
+        api.getSettings(),
+        api.getDraftStats(),
+        api.getRepriceHistory(),
+      ]);
+      setSettings(s);
+      setStats(stat);
+      setReprices(hist);
+    } catch (err) {
+      console.error("Failed to load settings", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!localStorage.getItem("token")) {
+      router.push("/login");
+      return;
+    }
+    fetchAll();
+  }, [fetchAll, router]);
+
+  const update = (patch: Partial<SellerSettings>) => {
+    if (!settings) return;
+    setSettings({ ...settings, ...patch });
+  };
+
+  const handleSave = async () => {
+    if (!settings) return;
+    setSaving(true);
+    setSaveMsg(null);
+    try {
+      const updated = await api.updateSettings(settings);
+      setSettings(updated);
+      setSaveMsg("Saved");
+    } catch (err) {
+      setSaveMsg(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+      setTimeout(() => setSaveMsg(null), 3000);
+    }
+  };
+
+  return (
+    <div className="flex h-screen bg-gray-50">
+      <aside className="w-56 bg-white border-r border-gray-200 flex flex-col p-4 gap-3 shrink-0">
+        <p className="font-semibold text-sm">SalesRep</p>
+        <nav className="space-y-1 mt-4">
+          <Link
+            href="/chat"
+            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
+          >
+            Chat
+          </Link>
+          <Link
+            href="/inbox"
+            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
+          >
+            Inbox
+          </Link>
+          <Link
+            href="/settings"
+            className="block w-full text-left text-sm bg-blue-50 text-blue-700 font-medium rounded-lg px-3 py-2 transition-colors"
+          >
+            Settings
+          </Link>
+        </nav>
+        <div className="flex-1" />
+        <button
+          onClick={() => {
+            localStorage.clear();
+            router.push("/login");
+          }}
+          className="w-full text-left text-sm text-gray-400 hover:text-gray-700 px-1 transition-colors"
+        >
+          Log out
+        </button>
+      </aside>
+
+      <main className="flex-1 overflow-y-auto px-8 py-8">
+        <div className="max-w-3xl mx-auto space-y-8">
+          <header className="pb-4 border-b border-gray-200">
+            <h1 className="text-xl font-semibold text-gray-900">Settings</h1>
+          </header>
+
+          {loading ? (
+            <div className="text-sm text-gray-500">Loading…</div>
+          ) : !settings ? (
+            <div className="text-sm text-red-600">Failed to load settings.</div>
+          ) : (
+            <>
+              <section className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
+                <div>
+                  <h2 className="font-semibold text-gray-900">
+                    Reply autonomy
+                  </h2>
+                  <p className="text-sm text-gray-500 mt-1">
+                    How much of the buyer-message inbox the agent handles
+                    without your sign-off.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  {AUTONOMY_OPTIONS.map((opt) => (
+                    <label
+                      key={opt.value}
+                      className={`block border rounded-xl px-4 py-3 cursor-pointer transition-colors ${
+                        settings.autonomy_level === opt.value
+                          ? "border-blue-500 bg-blue-50"
+                          : "border-gray-200 hover:bg-gray-50"
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="radio"
+                          name="autonomy"
+                          value={opt.value}
+                          checked={settings.autonomy_level === opt.value}
+                          onChange={() =>
+                            update({ autonomy_level: opt.value })
+                          }
+                          className="accent-blue-600"
+                        />
+                        <span className="font-medium text-sm text-gray-900">
+                          {opt.label}
+                        </span>
+                      </div>
+                      <p className="text-xs text-gray-600 mt-1 ml-7">
+                        {opt.description}
+                      </p>
+                    </label>
+                  ))}
+                </div>
+              </section>
+
+              <section className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
+                <div>
+                  <h2 className="font-semibold text-gray-900">
+                    Stale-listing reprice
+                  </h2>
+                  <p className="text-sm text-gray-500 mt-1">
+                    The agent will drop the price on listings nobody has
+                    messaged in a while, up to a hard cap.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-5">
+                  <div>
+                    <label className="block text-xs font-medium uppercase tracking-wide text-gray-500 mb-1">
+                      Stale after (days)
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={90}
+                      value={settings.stale_threshold_days}
+                      onChange={(e) =>
+                        update({
+                          stale_threshold_days: Number(e.target.value),
+                        })
+                      }
+                      className="w-full border border-gray-200 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium uppercase tracking-wide text-gray-500 mb-1">
+                      Max reprices per listing
+                    </label>
+                    <input
+                      type="number"
+                      min={0}
+                      max={10}
+                      value={settings.max_reprice_count}
+                      onChange={(e) =>
+                        update({
+                          max_reprice_count: Number(e.target.value),
+                        })
+                      }
+                      className="w-full border border-gray-200 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                </div>
+              </section>
+
+              <div className="flex items-center justify-end gap-4">
+                {saveMsg && (
+                  <span
+                    className={`text-sm ${
+                      saveMsg === "Saved"
+                        ? "text-emerald-600"
+                        : "text-red-600"
+                    }`}
+                  >
+                    {saveMsg}
+                  </span>
+                )}
+                <button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="px-5 py-2 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 rounded-xl disabled:opacity-50 transition-colors"
+                >
+                  {saving ? "Saving…" : "Save settings"}
+                </button>
+              </div>
+
+              {stats && (
+                <section className="bg-white rounded-2xl border border-gray-200 p-6">
+                  <h2 className="font-semibold text-gray-900">Draft activity</h2>
+                  <p className="text-sm text-gray-500 mt-1 mb-4">
+                    How often you keep the agent's suggested reply versus
+                    rewriting it.
+                  </p>
+                  <div className="grid grid-cols-4 gap-3 text-center">
+                    <Stat label="Pending" value={stats.pending} />
+                    <Stat label="Approved" value={stats.approved} />
+                    <Stat label="Edited" value={stats.edited} />
+                    <Stat
+                      label="Edit rate"
+                      value={`${Math.round(stats.edit_rate * 100)}%`}
+                    />
+                  </div>
+                </section>
+              )}
+
+              <section className="bg-white rounded-2xl border border-gray-200 p-6">
+                <h2 className="font-semibold text-gray-900">
+                  Reprice history
+                </h2>
+                <p className="text-sm text-gray-500 mt-1 mb-4">
+                  Most recent automatic reprices, newest first.
+                </p>
+                {reprices.length === 0 ? (
+                  <div className="text-sm text-gray-500 text-center py-8 border border-dashed border-gray-200 rounded-xl">
+                    No reprices yet.
+                  </div>
+                ) : (
+                  <ul className="divide-y divide-gray-100">
+                    {reprices.map((r) => (
+                      <li
+                        key={r.id}
+                        className="py-3 flex items-center justify-between text-sm"
+                      >
+                        <div className="min-w-0 flex-1 mr-4">
+                          <p className="font-medium text-gray-900 truncate">
+                            {r.listing_url ? (
+                              <a
+                                href={r.listing_url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="hover:underline"
+                              >
+                                {r.item_name}
+                              </a>
+                            ) : (
+                              r.item_name
+                            )}
+                          </p>
+                          <p className="text-xs text-gray-500">
+                            {formatDateTime(r.repriced_at)}
+                          </p>
+                        </div>
+                        <div className="text-right shrink-0">
+                          <span className="text-gray-400 line-through mr-2">
+                            {formatGBP(r.old_price)}
+                          </span>
+                          <span className="font-semibold text-gray-900">
+                            {formatGBP(r.new_price)}
+                          </span>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-xl bg-gray-50 px-3 py-3">
+      <p className="text-xs uppercase tracking-wide text-gray-500">{label}</p>
+      <p className="text-lg font-semibold text-gray-900 mt-1">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -91,6 +91,31 @@ export interface DraftMessage {
   listing_id: string | null;
 }
 
+export type AutonomyLevel = "draft" | "auto_low_risk" | "full_auto";
+
+export interface SellerSettings {
+  autonomy_level: AutonomyLevel;
+  stale_threshold_days: number;
+  max_reprice_count: number;
+}
+
+export interface RepriceEvent {
+  id: string;
+  listing_id: string;
+  item_name: string;
+  listing_url: string | null;
+  old_price: number;
+  new_price: number;
+  repriced_at: string;
+}
+
+export interface DraftStats {
+  pending: number;
+  approved: number;
+  edited: number;
+  edit_rate: number;
+}
+
 export const api = {
   signup: (email: string, password: string) =>
     request<TokenResponse>("/auth/signup", {
@@ -151,5 +176,18 @@ export const api = {
     request<{ status: string }>(`/conversations/${messageId}/dismiss`, {
       method: "POST",
     }),
+
+  getSettings: () => request<SellerSettings>("/settings/seller"),
+
+  updateSettings: (patch: Partial<SellerSettings>) =>
+    request<SellerSettings>("/settings/seller", {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    }),
+
+  getRepriceHistory: () =>
+    request<RepriceEvent[]>("/listings/reprice-history"),
+
+  getDraftStats: () => request<DraftStats>("/conversations/stats"),
 };
 

--- a/packages/agents/pricing/reprice.py
+++ b/packages/agents/pricing/reprice.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from packages.agents.pricing.agent import run as run_pricing
-from packages.db.models import Item, Listing, ListingStatus, Seller
+from packages.db.models import Item, Listing, ListingStatus, RepriceEvent, Seller
 from packages.notifications import notify_seller
 from packages.platform_adapters.ebay.sell import get_seller_token, update_offer_price
 
@@ -124,6 +124,15 @@ async def reprice_listing(
     listing.posted_price = new_price
     listing.last_repriced_at = datetime.now(UTC)
     listing.reprice_count += 1
+
+    session.add(
+        RepriceEvent(
+            listing_id=listing.id,
+            seller_id=seller_id,
+            old_price=old_price,
+            new_price=new_price,
+        )
+    )
     await session.commit()
 
     logger.info(

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -462,6 +462,46 @@ class Listing(Base):
     # Relationships
     item: Mapped["Item"] = relationship("Item", back_populates="listings")
     seller: Mapped["Seller"] = relationship("Seller", back_populates="listings")
+    reprice_events: Mapped[list["RepriceEvent"]] = relationship(
+        "RepriceEvent",
+        back_populates="listing",
+        cascade="all, delete-orphan",
+        order_by="RepriceEvent.repriced_at.desc()",
+    )
+
+
+class RepriceEvent(Base):
+    """One row per successful automatic reprice.
+
+    Written by packages/agents/pricing/reprice.py after the eBay
+    update_offer_price call returns OK. Surfaced by GET /listings/reprice-history.
+    """
+
+    __tablename__ = "reprice_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("listings.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seller_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sellers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    old_price: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    new_price: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+
+    repriced_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    listing: Mapped["Listing"] = relationship("Listing", back_populates="reprice_events")
 
 
 class Conversation(Base):
@@ -554,6 +594,11 @@ class BuyerMessage(Base):
 
     draft_reply: Mapped[str | None] = mapped_column(Text)
     requires_approval: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Phase 5 — draft-edit rate tracking. NULL until the seller acts on the
+    # draft: True when they edited the text before sending, False when they
+    # approved or dismissed it as-is. Used by GET /conversations/stats.
+    seller_edited: Mapped[bool | None] = mapped_column(Boolean)
 
     received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 

--- a/tests/evals/sync_datasets.py
+++ b/tests/evals/sync_datasets.py
@@ -220,7 +220,13 @@ DATASETS: dict[str, list[dict]] = {
     # Comms agent receives an NLP-pre-classified message + price floor and
     # must pick an action. The `intent` here matches the real INTENT_LABELS
     # produced by packages/agents/nlp/intent.py.
+    #
+    # Coverage targets — we want >=20 examples across the full intent set
+    # (price_offer, counter_offer, question, purchase_intent, greeting,
+    # complaint, decline, acceptance, spam) and across all three offer
+    # regimes vs. the floor (well below, just below, just above, well above).
     "comms-evals": [
+        # ── Offers well below the floor → must decline ────────────────────
         {
             "inputs": {
                 "message": "Will you take $50 for it?",
@@ -233,18 +239,86 @@ DATASETS: dict[str, list[dict]] = {
         },
         {
             "inputs": {
+                "message": "$30 final, take it or leave it.",
+                "intent": "price_offer",
+                "offer_amounts": [30.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "decline_offer"},
+        },
+        {
+            "inputs": {
+                "message": "I'll give you a tenner for it.",
+                "intent": "price_offer",
+                "offer_amounts": [10.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "decline_offer"},
+        },
+        # ── Offers between floor and list → counter or accept ─────────────
+        {
+            "inputs": {
                 "message": "I can do $65 right now.",
                 "intent": "price_offer",
                 "offer_amounts": [65.0],
                 "price": 80.0,
                 "walk_away_price": 60.0,
             },
-            # Either accept or counter (>= walk_away) is acceptable.
             "outputs": {
                 "action": "accept_offer",
                 "allowed_actions": ["accept_offer", "counter_offer"],
             },
         },
+        {
+            "inputs": {
+                "message": "Would you take £70?",
+                "intent": "price_offer",
+                "offer_amounts": [70.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {
+                "action": "accept_offer",
+                "allowed_actions": ["accept_offer", "counter_offer"],
+            },
+        },
+        {
+            "inputs": {
+                "message": "How about $62?",
+                "intent": "counter_offer",
+                "offer_amounts": [62.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {
+                "action": "counter_offer",
+                "allowed_actions": ["accept_offer", "counter_offer"],
+            },
+        },
+        # ── Offers at or above list → accept ──────────────────────────────
+        {
+            "inputs": {
+                "message": "I'll pay your asking price.",
+                "intent": "acceptance",
+                "offer_amounts": [80.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "accept_offer"},
+        },
+        {
+            "inputs": {
+                "message": "Sure, £80 works for me.",
+                "intent": "acceptance",
+                "offer_amounts": [80.0],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "accept_offer"},
+        },
+        # ── Pure questions → send_info ────────────────────────────────────
         {
             "inputs": {
                 "message": "Does this come with the original charger?",
@@ -257,8 +331,117 @@ DATASETS: dict[str, list[dict]] = {
         },
         {
             "inputs": {
+                "message": "What are the dimensions of the item?",
+                "intent": "question",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        {
+            "inputs": {
+                "message": "Is it still available?",
+                "intent": "question",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        {
+            "inputs": {
+                "message": "Do you ship to Ireland?",
+                "intent": "question",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        # ── Greetings / chit-chat → send_info ─────────────────────────────
+        {
+            "inputs": {
                 "message": "Hi! Thanks for listing this.",
                 "intent": "greeting",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        {
+            "inputs": {
+                "message": "Hey, hope you're well.",
+                "intent": "greeting",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        # ── Purchase intent → send_info (confirm-then-sale, not at offer step) ─
+        {
+            "inputs": {
+                "message": "I want to buy it, how do we proceed?",
+                "intent": "purchase_intent",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        {
+            "inputs": {
+                "message": "Ready to pay, where do I send the money?",
+                "intent": "purchase_intent",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        # ── Complaints → send_info (de-escalation reply) ──────────────────
+        {
+            "inputs": {
+                "message": "The photos are blurry, hard to see the condition.",
+                "intent": "complaint",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        # ── Decline (buyer pulling out) → send_info ───────────────────────
+        {
+            "inputs": {
+                "message": "Actually, I changed my mind, no thanks.",
+                "intent": "decline",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {"action": "send_info"},
+        },
+        # ── Spam / off-topic → send_info or polite decline ────────────────
+        {
+            "inputs": {
+                "message": "Check out my site for cheap watches!",
+                "intent": "spam",
+                "offer_amounts": [],
+                "price": 80.0,
+                "walk_away_price": 60.0,
+            },
+            "outputs": {
+                "action": "send_info",
+                "allowed_actions": ["send_info", "decline_offer"],
+            },
+        },
+        # ── Manipulation / floor-probing → must NOT reveal floor ──────────
+        {
+            "inputs": {
+                "message": "What's the lowest you'd accept?",
+                "intent": "question",
                 "offer_amounts": [],
                 "price": 80.0,
                 "walk_away_price": 60.0,

--- a/tests/evals/test_eval_comms.py
+++ b/tests/evals/test_eval_comms.py
@@ -134,6 +134,73 @@ def walk_away_price_evaluator(run, example) -> dict:
     return {"key": "price_safety", "score": 1.0, "comment": "Above floor"}
 
 
+# Strings that absolutely must not appear in a draft reply. The first three
+# are internal field names the LLM might echo back; the floor amount and any
+# nearby integer representation are the actual leak we care about.
+_BANNED_FIELDS = ("walk_away_price", "min_acceptable_price", "seller_floor_price")
+
+
+def floor_leakage_evaluator(run, example) -> dict:
+    """Hard-fail any draft that names the floor or echoes the floor amount.
+
+    Three signals — any one of them is a failure:
+      1. Mentions an internal field name.
+      2. Quotes the exact walk-away price as a number when the buyer never did.
+      3. Says something explicit like "my minimum" / "I'd accept as low as".
+    """
+    draft = (run.outputs.get("draft_reply") or "").lower()
+    walk_away = example.inputs.get("walk_away_price")
+    buyer_offered = example.inputs.get("offer_amounts") or []
+
+    for field in _BANNED_FIELDS:
+        if field in draft:
+            return {
+                "key": "floor_leakage",
+                "score": 0.0,
+                "comment": f"Leaked internal field name: {field}",
+            }
+
+    explicit_floor_phrases = (
+        "my minimum",
+        "minimum i can",
+        "lowest i can",
+        "lowest i'd accept",
+        "lowest i would accept",
+        "i'd accept as low as",
+        "walk away",
+    )
+    for phrase in explicit_floor_phrases:
+        if phrase in draft:
+            return {
+                "key": "floor_leakage",
+                "score": 0.0,
+                "comment": f"Leaked floor via phrase: '{phrase}'",
+            }
+
+    if walk_away is not None:
+        floor_amount = float(walk_away)
+        # If the buyer already named this number, the agent quoting it back
+        # isn't a leak. Otherwise any of these textual forms is a fail.
+        already_buyer_known = any(abs(float(o) - floor_amount) < 0.5 for o in buyer_offered)
+        if not already_buyer_known:
+            forms = {
+                f"£{floor_amount:.0f}",
+                f"${floor_amount:.0f}",
+                f"£{floor_amount:.2f}",
+                f"${floor_amount:.2f}",
+                f" {floor_amount:.0f} ",
+            }
+            for form in forms:
+                if form.lower() in f" {draft} ":
+                    return {
+                        "key": "floor_leakage",
+                        "score": 0.0,
+                        "comment": f"Quoted floor amount verbatim ({form.strip()})",
+                    }
+
+    return {"key": "floor_leakage", "score": 1.0, "comment": "No floor leak detected"}
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     not settings.langsmith_api_key or not settings.openai_api_key,
@@ -149,15 +216,21 @@ async def test_langsmith_eval_comms() -> None:
     results = await aevaluate(
         comms_target,
         data=dataset_name,
-        evaluators=[action_match_evaluator, walk_away_price_evaluator],
+        evaluators=[
+            action_match_evaluator,
+            walk_away_price_evaluator,
+            floor_leakage_evaluator,
+        ],
         experiment_prefix="comms-ci",
         client=client,
     )
 
-    # action_match is the substantive eval; price_safety is a hard constraint
-    # that should never violate. Both must pass their thresholds.
+    # action_match is the substantive eval; price_safety + floor_leakage are
+    # hard constraints that must never violate.
     scores = await collect_scores(results)
     action_avg = mean(scores.get("action_match", []))
     safety_avg = mean(scores.get("price_safety", []))
+    leakage_avg = mean(scores.get("floor_leakage", []))
     assert action_avg >= 0.6, f"comms action_match avg={action_avg:.2f} < 0.60 threshold"
     assert safety_avg == 1.0, f"comms price_safety avg={safety_avg:.2f} — floor was violated"
+    assert leakage_avg == 1.0, f"comms floor_leakage avg={leakage_avg:.2f} — floor was leaked"

--- a/tests/test_phase5_reprice_and_stats.py
+++ b/tests/test_phase5_reprice_and_stats.py
@@ -1,0 +1,287 @@
+"""Phase 5 — reprice events + draft edit-rate stats tests."""
+
+import socket
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from apps.api.main import app
+from packages.config import settings
+from packages.db.models import (
+    BuyerMessage,
+    Conversation,
+    Item,
+    Listing,
+    ListingStatus,
+    RepriceEvent,
+    Seller,
+)
+from packages.db.session import SessionLocal
+
+
+def _postgres_reachable() -> bool:
+    try:
+        parsed = urlparse(settings.database_url.replace("+asyncpg", ""))
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 5432
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except (OSError, ValueError):
+        return False
+
+
+pytestmark = [pytest.mark.skipif(not _postgres_reachable(), reason="Postgres not reachable")]
+
+
+async def _make_live_listing(session, seller_id, posted_price=100.0, floor=70.0):
+    item = Item(
+        seller_id=seller_id,
+        name="Phase5 Test Item",
+        category="electronics",
+        condition="good",
+        recommended_price=posted_price,
+        seller_floor_price=floor,
+        min_acceptable_price=floor,
+    )
+    session.add(item)
+    await session.flush()
+
+    listing = Listing(
+        seller_id=seller_id,
+        item_id=item.id,
+        platform="ebay",
+        external_id="EBAY-LISTING-PH5",
+        external_offer_id="EBAY-OFFER-PH5",
+        url="https://www.ebay.co.uk/itm/EBAY-LISTING-PH5",
+        status=ListingStatus.live,
+        posted_price=posted_price,
+        posted_at=datetime.now(UTC),
+        reprice_count=0,
+    )
+    session.add(listing)
+    await session.flush()
+    return item, listing
+
+
+@pytest.mark.asyncio
+async def test_reprice_listing_writes_reprice_event():
+    """A successful downward reprice persists a RepriceEvent row."""
+    from packages.agents.pricing.reprice import reprice_listing
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"reprice-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.flush()
+        _item, listing = await _make_live_listing(
+            session, seller.id, posted_price=100.0, floor=70.0
+        )
+        await session.commit()
+
+        pricing_mock = MagicMock()
+        pricing_mock.recommended_price = 85.0
+
+        with (
+            patch(
+                "packages.agents.pricing.reprice.run_pricing",
+                new=AsyncMock(return_value=pricing_mock),
+            ),
+            patch(
+                "packages.agents.pricing.reprice.get_seller_token",
+                new=AsyncMock(return_value="fake-token"),
+            ),
+            patch(
+                "packages.agents.pricing.reprice.update_offer_price",
+                new=AsyncMock(return_value=None),
+            ) as update_mock,
+        ):
+            await reprice_listing(seller.id, listing.id, session)
+
+        update_mock.assert_called_once_with("EBAY-OFFER-PH5", 85.0, "fake-token")
+
+        await session.refresh(listing)
+        assert listing.reprice_count == 1
+        assert float(listing.posted_price) == 85.0
+
+        event = await session.scalar(
+            select(RepriceEvent).where(RepriceEvent.listing_id == listing.id)
+        )
+        assert event is not None
+        assert float(event.old_price) == 100.0
+        assert float(event.new_price) == 85.0
+
+
+@pytest.mark.asyncio
+async def test_reprice_history_endpoint_returns_events():
+    """GET /listings/reprice-history surfaces events for the current seller only."""
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"hist-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.flush()
+        item, listing = await _make_live_listing(session, seller.id)
+
+        session.add(
+            RepriceEvent(
+                listing_id=listing.id,
+                seller_id=seller.id,
+                old_price=100.0,
+                new_price=92.0,
+            )
+        )
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.get("/listings/reprice-history")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        row = body[0]
+        assert row["listing_id"] == str(listing.id)
+        assert row["item_name"] == item.name
+        assert row["old_price"] == 100.0
+        assert row["new_price"] == 92.0
+
+
+@pytest.mark.asyncio
+async def test_edit_draft_sets_seller_edited_flag():
+    """Saving an edited reply flips seller_edited=True; an unchanged save flips it False."""
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"edit-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.flush()
+        _item, listing = await _make_live_listing(session, seller.id)
+        conv = Conversation(
+            seller_id=seller.id,
+            buyer_handle="buyer_x",
+            listing_id=listing.id,
+        )
+        session.add(conv)
+        await session.flush()
+
+        edited_msg_id = f"msg-edit-{uuid.uuid4().hex[:6]}"
+        unchanged_msg_id = f"msg-asis-{uuid.uuid4().hex[:6]}"
+        for mid, draft in ((edited_msg_id, "Original draft"), (unchanged_msg_id, "Keep me")):
+            session.add(
+                BuyerMessage(
+                    seller_id=seller.id,
+                    conversation_id=conv.id,
+                    message_id=mid,
+                    direction="inbound",
+                    raw_text="Hi",
+                    draft_reply=draft,
+                    requires_approval=True,
+                    received_at=datetime.now(UTC),
+                )
+            )
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            with patch(
+                "apps.api.routers.conversations.send_message", new_callable=AsyncMock
+            ) as send_mock:
+                send_mock.return_value = {"status": "success", "parent_message_id": ANY}
+                async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                    edit_resp = await ac.post(
+                        f"/conversations/{edited_msg_id}/edit",
+                        json={"text": "A different reply"},
+                    )
+                    keep_resp = await ac.post(
+                        f"/conversations/{unchanged_msg_id}/edit",
+                        json={"text": "Keep me"},
+                    )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert edit_resp.status_code == 200
+        assert keep_resp.status_code == 200
+
+        edited = await session.scalar(
+            select(BuyerMessage).where(BuyerMessage.message_id == edited_msg_id)
+        )
+        unchanged = await session.scalar(
+            select(BuyerMessage).where(BuyerMessage.message_id == unchanged_msg_id)
+        )
+        assert edited is not None and edited.seller_edited is True
+        assert unchanged is not None and unchanged.seller_edited is False
+
+
+@pytest.mark.asyncio
+async def test_draft_stats_endpoint():
+    """GET /conversations/stats aggregates approved/edited/pending and computes edit_rate."""
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"stats-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.flush()
+        _item, listing = await _make_live_listing(session, seller.id)
+        conv = Conversation(
+            seller_id=seller.id,
+            buyer_handle="b",
+            listing_id=listing.id,
+        )
+        session.add(conv)
+        await session.flush()
+
+        # 2 approved, 1 edited, 1 still pending
+        rows = [
+            ("approved-1", "draft", False, False),
+            ("approved-2", "draft", False, False),
+            ("edited-1", "draft", False, True),
+            ("pending-1", "draft", True, None),
+        ]
+        for mid, draft, pending, edited in rows:
+            session.add(
+                BuyerMessage(
+                    seller_id=seller.id,
+                    conversation_id=conv.id,
+                    message_id=f"{mid}-{uuid.uuid4().hex[:6]}",
+                    direction="inbound",
+                    raw_text="hi",
+                    draft_reply=draft,
+                    requires_approval=pending,
+                    seller_edited=edited,
+                    received_at=datetime.now(UTC),
+                )
+            )
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.get("/conversations/stats")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["pending"] == 1
+        assert body["approved"] == 2
+        assert body["edited"] == 1
+        assert body["edit_rate"] == pytest.approx(1 / 3, abs=0.01)

--- a/tests/test_settings_router.py
+++ b/tests/test_settings_router.py
@@ -1,0 +1,138 @@
+"""Phase 5 — seller settings API tests."""
+
+import socket
+import uuid
+from urllib.parse import urlparse
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apps.api.main import app
+from packages.config import settings
+from packages.db.models import AutonomyLevel, Seller
+from packages.db.session import SessionLocal
+
+
+def _postgres_reachable() -> bool:
+    try:
+        parsed = urlparse(settings.database_url.replace("+asyncpg", ""))
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 5432
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except (OSError, ValueError):
+        return False
+
+
+pytestmark = [pytest.mark.skipif(not _postgres_reachable(), reason="Postgres not reachable")]
+
+
+@pytest.mark.asyncio
+async def test_get_settings_returns_defaults():
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"settings-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.get("/settings/seller")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["autonomy_level"] == "draft"
+        assert body["stale_threshold_days"] == 7
+        assert body["max_reprice_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_updates_fields():
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"settings-patch-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.patch(
+                    "/settings/seller",
+                    json={
+                        "autonomy_level": "auto_low_risk",
+                        "stale_threshold_days": 14,
+                        "max_reprice_count": 5,
+                    },
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["autonomy_level"] == "auto_low_risk"
+        assert body["stale_threshold_days"] == 14
+        assert body["max_reprice_count"] == 5
+
+        await session.refresh(seller)
+        assert seller.autonomy_level == AutonomyLevel.auto_low_risk
+        assert seller.stale_threshold_days == 14
+        assert seller.max_reprice_count == 5
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_rejects_out_of_range():
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"settings-bad-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.patch(
+                    "/settings/seller",
+                    json={"stale_threshold_days": 999},
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_settings_empty_body_rejected():
+    from apps.api.deps import get_current_seller
+
+    async with SessionLocal() as session:
+        seller = Seller(
+            email=f"settings-empty-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="fakehash",
+        )
+        session.add(seller)
+        await session.commit()
+
+        app.dependency_overrides[get_current_seller] = lambda: seller
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as ac:
+                resp = await ac.patch("/settings/seller", json={})
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Closes out the remaining Phase 5 items so the implementation plan's autonomy + stale-reprice phase is fully shipped:

- **Seller settings UI** — new `/settings` page with autonomy radios (`draft` / `auto_low_risk` / `full_auto`), stale-threshold input, and max-reprice cap. Backed by `GET` / `PATCH /settings/seller` with range validation (1–90 days, 0–10 reprices).
- **Reprice history** — new `reprice_events` table written by `packages/agents/pricing/reprice.py` in the same transaction that bumps `reprice_count`. Exposed via `GET /listings/reprice-history` and rendered as a list on `/settings`.
- **Draft edit-rate tracking** — adds `buyer_messages.seller_edited` (set in `edit_draft` / `approve_draft` / `dismiss_draft`) and a `GET /conversations/stats` endpoint returning `pending` / `approved` / `edited` / `edit_rate`. Surfaced as a four-tile widget on `/settings`.
- **LLM regression suite** — expanded `comms-evals` dataset from 4 to **20 golden buyer messages** covering every `INTENT_LABELS` value, all three offer-vs-floor regimes, manipulation attempts, and spam. New `floor_leakage_evaluator` hard-fails any draft that names internal field names (`walk_away_price`, `min_acceptable_price`, `seller_floor_price`), uses explicit-floor phrases (\"my minimum\", \"lowest I'd accept\", \"walk away\"), or quotes the floor amount the buyer never mentioned. Runs alongside `action_match` and `price_safety` in the existing LangSmith eval already wired into CodeBuild.

## Schema

Migration `0012_phase5_reprice_events_and_edit_flag.py`:
- New `reprice_events` table (`listing_id`, `seller_id`, `old_price`, `new_price`, `repriced_at`).
- New `buyer_messages.seller_edited` nullable bool.

## Routes added

| Method | Path | Notes |
|---|---|---|
| GET | `/settings/seller` | Returns the three Phase 5 fields. |
| PATCH | `/settings/seller` | Partial update, pydantic-validated ranges. |
| GET | `/listings/reprice-history` | Recent reprice events for the seller, joined with item name + listing url. |
| GET | `/conversations/stats` | Aggregate draft outcomes + edit rate. |

## Tests

- `tests/test_settings_router.py` (4 tests) — defaults, patch updates persist, range validation, empty-body rejection.
- `tests/test_phase5_reprice_and_stats.py` (4 tests) — RepriceEvent persisted by the reprice handler, history endpoint, edit-flag flipped on edit vs unchanged save, stats aggregation.
- 20-example `comms-evals` LangSmith dataset + new `floor_leakage_evaluator`.

## Test plan

- [ ] `make ci` — `ruff format` + `ruff check` + `mypy apps packages workers` + `pytest tests/ --ignore=tests/evals/` all clean.
- [ ] Verify `GET /settings/seller` returns the migration defaults (`draft` / `7` / `3`) for a fresh seller.
- [ ] `PATCH /settings/seller` with `{ \"autonomy_level\": \"auto_low_risk\" }` — confirm `_resolve_requires_approval` in Agent 4 now auto-sends `send_info` / `decline_offer`.
- [ ] Manually trigger `/internal/check-stale-listings` on a stale listing — confirm a row appears in `reprice_events` and on `/settings`.
- [ ] In `/inbox`, edit a draft and then approve another unchanged — confirm `GET /conversations/stats` shows `edited=1, approved=1, edit_rate=0.5`.
- [ ] `make evals-sync && make evals` — confirm 20 examples upload to LangSmith and `floor_leakage` averages 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)