### PR TITLE
feat: Phase 6.0 + Phase 7 — prediction logging, Stripe billing, onboa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,160 @@
-# Multi-Agent AI Selling Assistant
+# SalesRep — AI-Powered eBay Selling Assistant
 
-A 5-agent system that helps sellers list items online: chat-based intake, ML-based price prediction, cross-platform listing, automated buyer negotiation, and continuous NLP feedback.
+SalesRep is a multi-agent system that automates eBay selling: chat-based item intake, ML price prediction, automatic listing publication, and AI-driven buyer negotiation with seller-controlled autonomy.
 
-See [`implementation_plan.md`](./implementation_plan.md) for the full architecture, tech stack, database schema, ML plan, and phased roadmap.
+**Live demo:** [devopslearn.store](https://devopslearn.store/) — click "Try the live demo" on the login page.
 
 ---
 
-## Status: Phase 0 — Scaffolding
+## What it does
 
-Infrastructure stands up, `/health` responds, smoke test passes. No business logic yet.
+| Feature | Detail |
+|---|---|
+| **Chat intake** | Describe an item in plain English; the agent extracts name, condition, category, and prompts for photos. |
+| **ML pricing** | LightGBM v3 model trained on eBay sold listings; returns recommended price + confidence interval. |
+| **eBay listing** | Publishes directly to eBay via Sell API (inventory + offers). |
+| **Buyer inbox** | eBay webhooks deliver buyer messages; Agent 4 drafts replies and sends them per your autonomy setting. |
+| **Draft approval** | Review and edit every draft, or flip to Auto mode to let the agent handle low-risk replies automatically. |
+| **Stale reprice** | Listings with no buyer activity for *N* days are automatically discounted via EventBridge. |
+| **Stripe billing** | Free tier (1 listing) and Pro tier (unlimited). Checkout and portal via Stripe. |
+| **Onboarding** | 3-step guided setup: connect eBay → choose reply mode → go. |
+| **Demo mode** | Shared read-only account with seeded listings and inbox drafts. |
 
-## Quick start
+---
 
-Install [uv](https://docs.astral.sh/uv/) if you don't have it:
-
-```
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Bootstrap:
-
-```
-cp .env.example .env
-make install        # uv sync --extra dev
-make up             # start postgres, redis, minio, api, celery-worker, celery-beat
-make test           # run the smoke test
-```
-
-Then hit:
-
-- API:         http://localhost:8000/health
-- OpenAPI:     http://localhost:8000/docs
-- MinIO UI:    http://localhost:9001  (user/pass: minioadmin / minioadmin)
-
-## Layout
+## Architecture
 
 ```
-apps/api/            FastAPI app — LangGraph orchestrator lives here (later phases)
+apps/
+  api/          FastAPI — routers: auth, billing, conversations, ebay,
+                          intake, internal, listings, settings, webhooks
+  web/          Next.js 15 seller dashboard (App Router, TypeScript, Tailwind)
+
 packages/
-  agents/            One submodule per agent (intake, pricing, publisher, comms, nlp)
-  platform_adapters/ ebay / gumtree / facebook
-  db/                SQLAlchemy Base + async session factory
-  bus/               Redis Streams helpers (Phase 1+)
-  ml/                XGBoost training + model registry (Phase 2)
-  schemas/           Pydantic shared payloads
-  config.py          Settings loaded from .env
-workers/             Celery entrypoints
-tests/               pytest
-alembic/             DB migrations
+  agents/       LangGraph agents: intake, pricing, publisher, comms
+  agents/nlp/   NLP pipeline (spaCy + transformers) used by Agent 4
+  agents/pricing/reprice.py   Stale-listing auto-reprice (Phase 5)
+  db/           SQLAlchemy ORM models + Alembic migrations
+  ml/           LightGBM v3 artifacts + model registry
+  platform_adapters/ebay/     Sell, Messaging, Browse, OAuth, Notifications
+  bus/          SQS enqueue helpers + EventBridge emit
+  config.py     Single pydantic-settings Settings object
+  auth.py       JWT creation/decoding, bcrypt, AES-GCM token encryption
+  storage.py    S3/MinIO image upload
+  notifications.py  SNS email push
+
+workers/
+  sqs_worker.py  Long-poll SQS worker (run_pipeline, process_buyer_message, reprice_listing, …)
+
+alembic/        DB migrations (0001 → 0014)
+scripts/        seed_demo.py — populates demo account with fixture data
+tests/          pytest smoke tests
 ```
 
-## Common commands
+**Database:** PostgreSQL 16 + pgvector. All seller tables carry `seller_id` + PostgreSQL RLS policies.
 
-```
-make help           list every target
-make up / down      docker compose up -d  /  down
-make logs           tail logs
-make test           pytest
-make fmt / lint     ruff format / check
-make migrate        alembic upgrade head
-make migration msg="add items table"    # autogenerate a revision
+**Deployment:** EC2 t3.medium running Docker Compose (postgres + api + sqs-worker). CI via AWS CodeBuild → SSM RunCommand on push to `main`.
+
+---
+
+## Quick start (local)
+
+Prerequisites: [uv](https://docs.astral.sh/uv/), Docker, Node 20+.
+
+```bash
+cp .env.example .env        # fill in OPENAI_API_KEY and JWT_SECRET_KEY at minimum
+make install                # uv sync --extra dev
+make up                     # postgres + api + sqs-worker
+make migrate                # apply all Alembic migrations
 ```
 
-## Optional dependency groups
+Frontend:
+```bash
+cd apps/web
+npm install
+npm run dev                 # http://localhost:3000
+```
 
+API:
+- Health:   http://localhost:8000/health
+- OpenAPI:  http://localhost:8000/docs
+- MinIO UI: http://localhost:9001  (minioadmin / minioadmin)
+
+---
+
+## Key environment variables
+
+| Variable | Purpose |
+|---|---|
+| `DATABASE_URL` | Postgres connection string (asyncpg) |
+| `JWT_SECRET_KEY` | HS256 signing key |
+| `TOKEN_ENCRYPTION_KEY` | AES-256-GCM key for eBay OAuth tokens (base64url, 32 bytes) |
+| `OPENAI_API_KEY` | Powers all 4 LangGraph agents |
+| `EBAY_CLIENT_ID` / `EBAY_CLIENT_SECRET` | eBay Sell + Messaging APIs |
+| `EBAY_DEV_ID` | SOAP NotificationSignature verification |
+| `EBAY_RU_NAME` / `EBAY_REDIRECT_URI` | OAuth callback |
+| `SQS_QUEUE_URL` | If set, webhooks enqueue to SQS; otherwise falls back to BackgroundTasks |
+| `S3_PUBLIC_BASE_URL` | Public image URL eBay will fetch (empty = MinIO local) |
+| `STRIPE_SECRET_KEY` | Stripe API key (leave empty to disable billing) |
+| `STRIPE_PRICE_ID_PRO` | Stripe price ID for the Pro plan |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret |
+| `BILLING_ENABLED` | Set to `true` to enable billing endpoints |
+| `FRONTEND_BASE_URL` | Stripe redirect target (e.g. `https://devopslearn.store`) |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated origins allowed to call the API |
+
+---
+
+## Common make targets
+
+```bash
+make up / down / logs / ps    # Docker Compose lifecycle
+make install                  # uv sync --extra dev
+make install-ml               # add LightGBM / pandas / numpy extras
+make install-nlp              # add spaCy / sentence-transformers extras
+make test                     # pytest
+make fmt / lint / mypy / ci   # code quality
+make migrate                  # alembic upgrade head
+make migration msg="..."      # autogenerate new migration
+make shell-db / shell-api     # psql / bash into running containers
+make worker                   # run SQS worker locally
+make subscribe-messages       # backfill eBay notification subscriptions
 ```
-make install-ml    # XGBoost, scikit-learn, pandas, numpy    (Phase 2)
-make install-nlp   # spaCy only; pricing model deps are part of the base install
-uv sync --extra scraping   # Scrapy, Playwright              (Phase 2/5)
+
+---
+
+## Billing setup (Stripe)
+
+1. Create a recurring price in Stripe dashboard; copy the `price_xxx` ID to `STRIPE_PRICE_ID_PRO`.
+2. Add a webhook endpoint pointing at `https://<your-domain>/billing/webhook` with events: `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`.
+3. Set `BILLING_ENABLED=true`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` in `.env`.
+
+---
+
+## Demo mode
+
+Seed the demo account after running migrations:
+
+```bash
+# 1. Ensure the demo seller exists (creates it if absent):
+curl https://<host>/auth/demo
+
+# 2. Populate fixture data:
+uv run python scripts/seed_demo.py
 ```
+
+The demo account (`demo@salesrep.app`) is read-only — mutating endpoints return `403 Forbidden` for `is_demo=true` sellers.
+
+---
+
+## Phase status
+
+| Phase | Description | Status |
+|---|---|---|
+| 0 | Scaffolding — FastAPI, Postgres, Docker Compose | ✅ Done |
+| 1 | Chat intake agent (Agent 1) + image upload | ✅ Done |
+| 2 | ML pricing agent (Agent 2) + LightGBM v3 | ✅ Done |
+| 3 | eBay publisher (Agent 3) + Sell API | ✅ Done |
+| 4 | Buyer comms agent (Agent 4) + NLP pipeline | ✅ Done |
+| 5 | Autonomy controls + stale-listing reprice | ✅ Done |
+| 6 | ML retraining loop data capture | ✅ Schema + prediction logging done |
+| 7 | Stripe billing + onboarding + demo mode + UI polish | ✅ Done |

--- a/alembic/versions/0013_phase6_prediction_logging.py
+++ b/alembic/versions/0013_phase6_prediction_logging.py
@@ -1,0 +1,188 @@
+"""Phase 6.0 — price prediction logging tables
+
+Adds the three tables needed for the ML retraining loop data-capture:
+  - model_versions: artifact registry
+  - price_predictions: point-in-time feature snapshot per Agent 2 call
+  - comparable_listings: validated eBay comparables per prediction
+
+Seeds the current v3 model as the active version so Agent 2 can tag
+predictions with a model_version_id from day one.
+
+Revision ID: 0013_phase6a
+Revises: 0012_phase5b
+Create Date: 2026-05-15
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0013_phase6a"
+down_revision: str | None = "0012_phase5b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE model_status AS ENUM ('training', 'shadow', 'active', 'archived', 'failed')")
+
+    op.create_table(
+        "model_versions",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("version", sa.Text(), nullable=False),
+        sa.Column("algorithm", sa.Text(), nullable=False, server_default="lightgbm"),
+        sa.Column("artifact_s3_key", sa.Text(), nullable=True),
+        sa.Column("feature_cols", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("train_metrics", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("shadow_metrics", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("training_row_count", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Enum("training", "shadow", "active", "archived", "failed", name="model_status", create_type=False),
+            nullable=False,
+            server_default="training",
+        ),
+        sa.Column("trained_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    # At most one active model at a time
+    op.create_index(
+        "ix_model_versions_active_unique",
+        "model_versions",
+        ["status"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+
+    op.create_table(
+        "price_predictions",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "seller_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sellers.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "item_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("items.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "listing_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("listings.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column(
+            "model_version_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("model_versions.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("features", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("features_partial", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("model_prediction", sa.Numeric(12, 2), nullable=True),
+        sa.Column("comparable_median", sa.Numeric(12, 2), nullable=True),
+        sa.Column("recommended_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("min_acceptable_price", sa.Numeric(12, 2), nullable=False),
+        sa.Column("confidence_score", sa.Numeric(5, 4), nullable=True),
+        sa.Column("is_shadow", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("realized_sale_price", sa.Numeric(12, 2), nullable=True),
+        sa.Column("realized_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_price_predictions_model_shadow",
+        "price_predictions",
+        ["model_version_id", "is_shadow"],
+    )
+
+    op.create_table(
+        "comparable_listings",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "price_prediction_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("price_predictions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "seller_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sellers.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("external_item_id", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("price", sa.Numeric(12, 2), nullable=True),
+        sa.Column("currency", sa.Text(), nullable=True),
+        sa.Column("condition", sa.Text(), nullable=True),
+        sa.Column("listing_url", sa.Text(), nullable=True),
+        sa.Column("relevance", sa.Text(), nullable=True),
+        sa.Column(
+            "captured_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # RLS policies mirroring 0002_rls_policies.py
+    for table in ("price_predictions", "comparable_listings"):
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"""
+            CREATE POLICY {table}_seller_isolation ON {table}
+            USING (seller_id = current_setting('app.current_seller_id', true)::uuid)
+        """)
+
+    # Seed the current v3 model as active
+    v3_id = str(uuid.uuid4())
+    op.execute(f"""
+        INSERT INTO model_versions (id, version, algorithm, status, notes, trained_at, promoted_at)
+        VALUES (
+            '{v3_id}',
+            'v3',
+            'lightgbm',
+            'active',
+            'Initial production model — LightGBM v3, trained on eBay UK active listings',
+            NOW(),
+            NOW()
+        )
+    """)
+
+
+def downgrade() -> None:
+    for table in ("price_predictions", "comparable_listings"):
+        op.execute(f"DROP POLICY IF EXISTS {table}_seller_isolation ON {table}")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")
+
+    op.drop_index("ix_price_predictions_model_shadow", table_name="price_predictions")
+    op.drop_index("ix_model_versions_active_unique", table_name="model_versions")
+    op.drop_table("comparable_listings")
+    op.drop_table("price_predictions")
+    op.drop_table("model_versions")
+    op.execute("DROP TYPE IF EXISTS model_status")

--- a/alembic/versions/0013_phase6_prediction_logging.py
+++ b/alembic/versions/0013_phase6_prediction_logging.py
@@ -27,7 +27,9 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute("CREATE TYPE model_status AS ENUM ('training', 'shadow', 'active', 'archived', 'failed')")
+    op.execute(
+        "CREATE TYPE model_status AS ENUM ('training', 'shadow', 'active', 'archived', 'failed')"
+    )
 
     op.create_table(
         "model_versions",
@@ -41,7 +43,15 @@ def upgrade() -> None:
         sa.Column("training_row_count", sa.Integer(), nullable=True),
         sa.Column(
             "status",
-            sa.Enum("training", "shadow", "active", "archived", "failed", name="model_status", create_type=False),
+            sa.Enum(
+                "training",
+                "shadow",
+                "active",
+                "archived",
+                "failed",
+                name="model_status",
+                create_type=False,
+            ),
             nullable=False,
             server_default="training",
         ),

--- a/alembic/versions/0014_phase7_billing_onboarding.py
+++ b/alembic/versions/0014_phase7_billing_onboarding.py
@@ -32,8 +32,13 @@ def upgrade() -> None:
     )
 
     # Onboarding + demo
-    op.add_column("sellers", sa.Column("onboarding_completed", sa.Boolean(), nullable=False, server_default="false"))
-    op.add_column("sellers", sa.Column("is_demo", sa.Boolean(), nullable=False, server_default="false"))
+    op.add_column(
+        "sellers",
+        sa.Column("onboarding_completed", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.add_column(
+        "sellers", sa.Column("is_demo", sa.Boolean(), nullable=False, server_default="false")
+    )
 
     # Stripe billing
     op.add_column("sellers", sa.Column("stripe_customer_id", sa.Text(), nullable=True))
@@ -50,13 +55,23 @@ def upgrade() -> None:
         "sellers",
         sa.Column(
             "subscription_status",
-            sa.Enum("none", "trialing", "active", "past_due", "canceled", name="subscription_status", create_type=False),
+            sa.Enum(
+                "none",
+                "trialing",
+                "active",
+                "past_due",
+                "canceled",
+                name="subscription_status",
+                create_type=False,
+            ),
             nullable=False,
             server_default="none",
         ),
     )
     op.add_column("sellers", sa.Column("stripe_subscription_id", sa.Text(), nullable=True))
-    op.add_column("sellers", sa.Column("current_period_end", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "sellers", sa.Column("current_period_end", sa.DateTime(timezone=True), nullable=True)
+    )
 
 
 def downgrade() -> None:

--- a/alembic/versions/0014_phase7_billing_onboarding.py
+++ b/alembic/versions/0014_phase7_billing_onboarding.py
@@ -1,0 +1,74 @@
+"""Phase 7 — billing + onboarding + demo columns on sellers
+
+Adds:
+  - sellers.onboarding_completed — lets the onboarding walkthrough be
+    dismissed and not re-shown
+  - sellers.is_demo — read-only demo account flag
+  - sellers.stripe_customer_id, plan, subscription_status,
+    stripe_subscription_id, current_period_end — Stripe billing
+
+Revision ID: 0014_phase7a
+Revises: 0013_phase6a
+Create Date: 2026-05-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0014_phase7a"
+down_revision: str | None = "0013_phase6a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE TYPE plan_tier AS ENUM ('free', 'pro')")
+    op.execute(
+        "CREATE TYPE subscription_status AS ENUM "
+        "('none', 'trialing', 'active', 'past_due', 'canceled')"
+    )
+
+    # Onboarding + demo
+    op.add_column("sellers", sa.Column("onboarding_completed", sa.Boolean(), nullable=False, server_default="false"))
+    op.add_column("sellers", sa.Column("is_demo", sa.Boolean(), nullable=False, server_default="false"))
+
+    # Stripe billing
+    op.add_column("sellers", sa.Column("stripe_customer_id", sa.Text(), nullable=True))
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "plan",
+            sa.Enum("free", "pro", name="plan_tier", create_type=False),
+            nullable=False,
+            server_default="free",
+        ),
+    )
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "subscription_status",
+            sa.Enum("none", "trialing", "active", "past_due", "canceled", name="subscription_status", create_type=False),
+            nullable=False,
+            server_default="none",
+        ),
+    )
+    op.add_column("sellers", sa.Column("stripe_subscription_id", sa.Text(), nullable=True))
+    op.add_column("sellers", sa.Column("current_period_end", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    for col in (
+        "current_period_end",
+        "stripe_subscription_id",
+        "subscription_status",
+        "plan",
+        "stripe_customer_id",
+        "is_demo",
+        "onboarding_completed",
+    ):
+        op.drop_column("sellers", col)
+    op.execute("DROP TYPE IF EXISTS subscription_status")
+    op.execute("DROP TYPE IF EXISTS plan_tier")

--- a/apps/api/deps.py
+++ b/apps/api/deps.py
@@ -45,3 +45,15 @@ async def get_current_seller(
     # Set the current seller ID in the session context (for RLS policies)
     await set_current_seller_id(session, seller.id)
     return seller
+
+
+async def require_not_demo(
+    seller: Seller = Depends(get_current_seller),
+) -> Seller:
+    """Block write operations for the shared demo account."""
+    if seller.is_demo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Demo account is read-only.",
+        )
+    return seller

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -62,6 +62,6 @@ app.include_router(images.router)  # Handles image storage/retrieval
 app.include_router(internal.router)  # Backend administrative tools
 app.include_router(listings.router)  # Listing-level endpoints (reprice history)
 app.include_router(settings_router.router)  # Seller autonomy + stale-reprice settings
-app.include_router(billing.router)          # Stripe checkout + portal + webhook
+app.include_router(billing.router)  # Stripe checkout + portal + webhook
 app.include_router(pages.router)  # Serves the static Frontend Files (Next.js Build)
 app.include_router(webhooks.router)  # Listens for eBay Events

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from apps.api.routers import (
     auth,
+    billing,
     conversations,
     ebay,
     health,
@@ -61,5 +62,6 @@ app.include_router(images.router)  # Handles image storage/retrieval
 app.include_router(internal.router)  # Backend administrative tools
 app.include_router(listings.router)  # Listing-level endpoints (reprice history)
 app.include_router(settings_router.router)  # Seller autonomy + stale-reprice settings
+app.include_router(billing.router)          # Stripe checkout + portal + webhook
 app.include_router(pages.router)  # Serves the static Frontend Files (Next.js Build)
 app.include_router(webhooks.router)  # Listens for eBay Events

--- a/apps/api/routers/auth.py
+++ b/apps/api/routers/auth.py
@@ -9,6 +9,9 @@ from packages.db.session import get_session
 from packages.notifications import create_seller_topic
 from packages.schemas.auth import LoginRequest, SignupRequest, TokenResponse
 
+_DEMO_EMAIL = "demo@salesrep.app"
+_DEMO_PASSWORD = "demo-salesrep-2025"
+
 # Create APIRouter for authentication endpoints with /auth prefix
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -63,3 +66,25 @@ async def login(body: LoginRequest, session: AsyncSession = Depends(get_session)
 
     # Return access token for the authenticated seller
     return TokenResponse(access_token=create_access_token(seller.id), seller_id=seller.id)
+
+
+@router.get("/demo", response_model=TokenResponse)
+async def demo_login(session: AsyncSession = Depends(get_session)) -> TokenResponse:
+    """Return a token for the shared read-only demo account.
+
+    The demo seller is created on first call and seeded with fixtures.
+    Mutating endpoints guard against is_demo=True sellers via the
+    `require_not_demo` dependency in apps/api/deps.py.
+    """
+    demo = await session.scalar(select(Seller).where(Seller.email == _DEMO_EMAIL))
+    if demo is None:
+        demo = Seller(
+            email=_DEMO_EMAIL,
+            hashed_password=hash_password(_DEMO_PASSWORD),
+            is_demo=True,
+            onboarding_completed=True,
+        )
+        session.add(demo)
+        await session.commit()
+        await session.refresh(demo)
+    return TokenResponse(access_token=create_access_token(demo.id), seller_id=demo.id)

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -38,7 +38,9 @@ async def billing_status(
     return {
         "plan": seller.plan.value,
         "subscription_status": seller.subscription_status.value,
-        "current_period_end": seller.current_period_end.isoformat() if seller.current_period_end else None,
+        "current_period_end": seller.current_period_end.isoformat()
+        if seller.current_period_end
+        else None,
     }
 
 
@@ -145,6 +147,7 @@ async def stripe_webhook(
         db_seller.stripe_subscription_id = data.get("id")
         if period_end:
             from datetime import datetime
+
             db_seller.current_period_end = datetime.fromtimestamp(period_end, tz=UTC)
 
         if new_status in (SubscriptionStatus.active, SubscriptionStatus.trialing):
@@ -154,6 +157,11 @@ async def stripe_webhook(
             db_seller.current_period_end = None
 
         await session.commit()
-        logger.info("Stripe subscription updated for seller %s: %s → %s", db_seller.id, event_type, new_status)
+        logger.info(
+            "Stripe subscription updated for seller %s: %s → %s",
+            db_seller.id,
+            event_type,
+            new_status,
+        )
 
     return {"status": "ok"}

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC
 from typing import Any
 
 import stripe
@@ -123,6 +124,7 @@ async def stripe_webhook(
         period_end: int | None = data.get("current_period_end")
 
         from sqlalchemy import select
+
         from packages.db.models import Seller as SellerModel
 
         db_seller = await session.scalar(
@@ -142,8 +144,8 @@ async def stripe_webhook(
         db_seller.subscription_status = new_status
         db_seller.stripe_subscription_id = data.get("id")
         if period_end:
-            from datetime import datetime, timezone
-            db_seller.current_period_end = datetime.fromtimestamp(period_end, tz=timezone.utc)
+            from datetime import datetime
+            db_seller.current_period_end = datetime.fromtimestamp(period_end, tz=UTC)
 
         if new_status in (SubscriptionStatus.active, SubscriptionStatus.trialing):
             db_seller.plan = PlanTier.pro

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -1,0 +1,157 @@
+"""Stripe billing — checkout, portal, status, and webhook handler."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import stripe
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api.deps import get_current_seller, require_not_demo
+from packages.config import settings
+from packages.db.models import PlanTier, Seller, SubscriptionStatus
+from packages.db.session import get_session
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+_SUCCESS_URL = f"{settings.frontend_base_url}/settings?billing=success"
+_CANCEL_URL = f"{settings.frontend_base_url}/settings"
+
+
+def _stripe() -> stripe.Stripe:
+    if not settings.billing_enabled or not settings.stripe_secret_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Billing is not enabled on this instance.",
+        )
+    return stripe.StripeClient(settings.stripe_secret_key)
+
+
+@router.get("/status")
+async def billing_status(
+    seller: Seller = Depends(get_current_seller),
+) -> dict[str, Any]:
+    return {
+        "plan": seller.plan.value,
+        "subscription_status": seller.subscription_status.value,
+        "current_period_end": seller.current_period_end.isoformat() if seller.current_period_end else None,
+    }
+
+
+@router.post("/checkout-session")
+async def create_checkout_session(
+    seller: Seller = Depends(require_not_demo),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    client = _stripe()
+
+    # Ensure the seller has a Stripe customer record
+    db_seller = await session.get(Seller, seller.id)
+    if db_seller is None:
+        raise HTTPException(status_code=404, detail="Seller not found")
+
+    customer_id: str | None = db_seller.stripe_customer_id
+    if not customer_id:
+        customer = client.customers.create(params={"email": db_seller.email})
+        customer_id = customer.id
+        db_seller.stripe_customer_id = customer_id
+        await session.commit()
+
+    checkout = client.checkout.sessions.create(
+        params={
+            "customer": customer_id,
+            "mode": "subscription",
+            "line_items": [{"price": settings.stripe_price_id_pro, "quantity": 1}],
+            "success_url": _SUCCESS_URL,
+            "cancel_url": _CANCEL_URL,
+            "metadata": {"seller_id": str(db_seller.id)},
+        }
+    )
+    return {"url": checkout.url}
+
+
+@router.post("/portal-session")
+async def create_portal_session(
+    seller: Seller = Depends(require_not_demo),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    client = _stripe()
+
+    db_seller = await session.get(Seller, seller.id)
+    if db_seller is None:
+        raise HTTPException(status_code=404, detail="Seller not found")
+    if not db_seller.stripe_customer_id:
+        raise HTTPException(status_code=400, detail="No billing account found. Upgrade first.")
+
+    portal = client.billing_portal.sessions.create(
+        params={"customer": db_seller.stripe_customer_id, "return_url": _CANCEL_URL}
+    )
+    return {"url": portal.url}
+
+
+@router.post("/webhook")
+async def stripe_webhook(
+    request: Request,
+    stripe_signature: str | None = Header(default=None, alias="stripe-signature"),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """Handle Stripe webhook events to keep subscription state in sync."""
+    if not settings.stripe_webhook_secret:
+        raise HTTPException(status_code=503, detail="Webhook secret not configured.")
+
+    payload = await request.body()
+    try:
+        event = stripe.Webhook.construct_event(
+            payload, stripe_signature or "", settings.stripe_webhook_secret
+        )
+    except stripe.SignatureVerificationError:
+        raise HTTPException(status_code=400, detail="Invalid Stripe signature.")
+
+    event_type: str = event["type"]
+    data: dict[str, Any] = event["data"]["object"]
+
+    if event_type in (
+        "customer.subscription.created",
+        "customer.subscription.updated",
+        "customer.subscription.deleted",
+    ):
+        customer_id: str = data["customer"]
+        sub_status_raw: str = data["status"]
+        period_end: int | None = data.get("current_period_end")
+
+        from sqlalchemy import select
+        from packages.db.models import Seller as SellerModel
+
+        db_seller = await session.scalar(
+            select(SellerModel).where(SellerModel.stripe_customer_id == customer_id)
+        )
+        if db_seller is None:
+            logger.warning("Stripe webhook: no seller for customer %s", customer_id)
+            return {"status": "ignored"}
+
+        status_map = {
+            "trialing": SubscriptionStatus.trialing,
+            "active": SubscriptionStatus.active,
+            "past_due": SubscriptionStatus.past_due,
+            "canceled": SubscriptionStatus.canceled,
+        }
+        new_status = status_map.get(sub_status_raw, SubscriptionStatus.none)
+        db_seller.subscription_status = new_status
+        db_seller.stripe_subscription_id = data.get("id")
+        if period_end:
+            from datetime import datetime, timezone
+            db_seller.current_period_end = datetime.fromtimestamp(period_end, tz=timezone.utc)
+
+        if new_status in (SubscriptionStatus.active, SubscriptionStatus.trialing):
+            db_seller.plan = PlanTier.pro
+        elif event_type == "customer.subscription.deleted":
+            db_seller.plan = PlanTier.free
+            db_seller.current_period_end = None
+
+        await session.commit()
+        logger.info("Stripe subscription updated for seller %s: %s → %s", db_seller.id, event_type, new_status)
+
+    return {"status": "ok"}

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -107,7 +107,7 @@ async def stripe_webhook(
 
     payload = await request.body()
     try:
-        event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
+        event = stripe.Webhook.construct_event(
             payload, stripe_signature or "", settings.stripe_webhook_secret
         )
     except stripe.SignatureVerificationError:

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -22,7 +22,7 @@ _SUCCESS_URL = f"{settings.frontend_base_url}/settings?billing=success"
 _CANCEL_URL = f"{settings.frontend_base_url}/settings"
 
 
-def _stripe() -> stripe.Stripe:
+def _stripe() -> stripe.StripeClient:
     if not settings.billing_enabled or not settings.stripe_secret_key:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -107,7 +107,7 @@ async def stripe_webhook(
 
     payload = await request.body()
     try:
-        event = stripe.Webhook.construct_event(
+        event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
             payload, stripe_signature or "", settings.stripe_webhook_secret
         )
     except stripe.SignatureVerificationError:

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -73,6 +73,8 @@ async def create_checkout_session(
             "metadata": {"seller_id": str(db_seller.id)},
         }
     )
+    if not checkout.url:
+        raise HTTPException(status_code=500, detail="Stripe did not return a checkout URL.")
     return {"url": checkout.url}
 
 
@@ -92,6 +94,8 @@ async def create_portal_session(
     portal = client.billing_portal.sessions.create(
         params={"customer": db_seller.stripe_customer_id, "return_url": _CANCEL_URL}
     )
+    if not portal.url:
+        raise HTTPException(status_code=500, detail="Stripe did not return a portal URL.")
     return {"url": portal.url}
 
 
@@ -107,7 +111,7 @@ async def stripe_webhook(
 
     payload = await request.body()
     try:
-        event = stripe.Webhook.construct_event(
+        event = stripe.Webhook.construct_event(  # type: ignore[no-untyped-call]
             payload, stripe_signature or "", settings.stripe_webhook_secret
         )
     except stripe.SignatureVerificationError:

--- a/apps/api/routers/billing.py
+++ b/apps/api/routers/billing.py
@@ -111,7 +111,7 @@ async def stripe_webhook(
             payload, stripe_signature or "", settings.stripe_webhook_secret
         )
     except stripe.SignatureVerificationError:
-        raise HTTPException(status_code=400, detail="Invalid Stripe signature.")
+        raise HTTPException(status_code=400, detail="Invalid Stripe signature.") from None
 
     event_type: str = event["type"]
     data: dict[str, Any] = event["data"]["object"]

--- a/apps/api/routers/settings.py
+++ b/apps/api/routers/settings.py
@@ -16,6 +16,8 @@ from apps.api.deps import get_current_seller
 from packages.db.models import AutonomyLevel, Seller
 from packages.db.session import get_session
 
+_DEMO_WRITE_FIELDS = {"autonomy_level", "stale_threshold_days", "max_reprice_count"}
+
 # get_current_seller and get_session may return objects from different
 # SQLAlchemy sessions when dependencies are overridden in tests. In production
 # they share a session, but the handlers below stay robust by re-fetching the
@@ -90,3 +92,23 @@ async def update_seller_settings(
     await session.commit()
     await session.refresh(db_seller)
     return _serialise(db_seller)
+
+
+@router.get("/seller/onboarding-status")
+async def get_onboarding_status(
+    seller: Seller = Depends(get_current_seller),
+) -> bool:
+    return bool(seller.onboarding_completed)
+
+
+@router.post("/seller/complete-onboarding")
+async def complete_onboarding(
+    seller: Seller = Depends(get_current_seller),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, bool]:
+    db_seller = await session.get(Seller, seller.id)
+    if db_seller is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Seller not found")
+    db_seller.onboarding_completed = True
+    await session.commit()
+    return {"ok": True}

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -2,8 +2,15 @@
 
 import { Suspense, useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
+import { Camera, Send } from "lucide-react";
 import { api, PricingResult, ListingStatus } from "@/lib/api";
+import { AppShell } from "@/components/AppShell";
+import { Toast, ToastType } from "@/components/Toast";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface Message {
   role: "user" | "assistant";
@@ -13,24 +20,25 @@ interface Message {
 }
 
 const POLL_INTERVAL_MS = 3000;
-const MAX_POLL_ATTEMPTS = 40; // 40 × 3s = 2 min max wait
+const MAX_POLL_ATTEMPTS = 40;
 
 function fmt(n: number) {
-  return n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+  return n.toLocaleString("en-GB", { style: "currency", currency: "GBP" });
 }
+
+/* ── Pricing panel ──────────────────────────────────────────────────── */
 
 function ConfidenceBar({ score }: { score: number }) {
   const pct = Math.round(score * 100);
-  const color =
-    pct >= 70 ? "bg-emerald-500" : pct >= 40 ? "bg-amber-400" : "bg-rose-400";
+  const color = pct >= 70 ? "bg-emerald-500" : pct >= 40 ? "bg-amber-400" : "bg-rose-400";
   return (
     <div className="space-y-1">
-      <div className="flex justify-between text-xs text-gray-500">
+      <div className="flex justify-between text-xs text-muted-foreground">
         <span>Confidence</span>
         <span>{pct}%</span>
       </div>
-      <div className="h-1.5 w-full rounded-full bg-gray-100">
-        <div className={`h-1.5 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      <div className="h-1.5 w-full rounded-full bg-muted">
+        <div className={`h-1.5 rounded-full ${color} transition-all`} style={{ width: `${pct}%` }} />
       </div>
     </div>
   );
@@ -39,204 +47,134 @@ function ConfidenceBar({ score }: { score: number }) {
 function PricingPanel({ pricing }: { pricing: PricingResult }) {
   const hasCI = pricing.price_low > 0 && pricing.price_high > 0;
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-5 space-y-4 shadow-sm">
-      {/* Headline price */}
-      <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-gray-400 mb-1">
-          Recommended price
-        </p>
-        <p className="text-3xl font-semibold text-gray-900">
-          {fmt(pricing.recommended_price)}
-        </p>
-        {hasCI && (
-          <p className="text-sm text-gray-500 mt-0.5">
-            Range&nbsp;
-            <span className="text-gray-700 font-medium">{fmt(pricing.price_low)}</span>
-            &nbsp;–&nbsp;
-            <span className="text-gray-700 font-medium">{fmt(pricing.price_high)}</span>
+    <Card>
+      <CardContent className="p-5 space-y-4">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-1">
+            Recommended price
+          </p>
+          <p className="text-3xl font-semibold">{fmt(pricing.recommended_price)}</p>
+          {hasCI && (
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Range{" "}
+              <span className="text-foreground font-medium">{fmt(pricing.price_low)}</span>
+              {" – "}
+              <span className="text-foreground font-medium">{fmt(pricing.price_high)}</span>
+            </p>
+          )}
+        </div>
+
+        <ConfidenceBar score={pricing.confidence_score} />
+
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Walk-away floor</span>
+          <span className="font-medium">{fmt(pricing.min_acceptable_price)}</span>
+        </div>
+
+        {pricing.comparables.length > 0 && (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+              Comparables ({pricing.comparables.length})
+            </p>
+            <div className="space-y-1.5 max-h-56 overflow-y-auto pr-1">
+              {pricing.comparables.map((c) => (
+                <a
+                  key={c.item_id}
+                  href={c.listing_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-start justify-between gap-3 rounded-xl border border-border px-3 py-2 hover:bg-accent/60 transition-colors group"
+                >
+                  <div className="min-w-0">
+                    <p className="text-xs truncate group-hover:text-foreground text-muted-foreground">{c.title}</p>
+                    <p className="text-xs text-muted-foreground/60 mt-0.5">{c.condition}</p>
+                  </div>
+                  <p className="text-sm font-medium shrink-0">{fmt(c.price)}</p>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {pricing.comparables.length === 0 && (
+          <p className="text-xs text-muted-foreground italic">
+            No live comparables — price based on model prediction only.
           </p>
         )}
-      </div>
-
-      <ConfidenceBar score={pricing.confidence_score} />
-
-      {/* Floor price */}
-      <div className="flex justify-between text-sm">
-        <span className="text-gray-500">Walk-away floor</span>
-        <span className="font-medium text-gray-700">
-          {fmt(pricing.min_acceptable_price)}
-        </span>
-      </div>
-
-      {/* Comparables */}
-      {pricing.comparables.length > 0 && (
-        <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-gray-400 mb-2">
-            Comparables ({pricing.comparables.length})
-          </p>
-          <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
-            {pricing.comparables.map((c) => (
-              <a
-                key={c.item_id}
-                href={c.listing_url}
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-start justify-between gap-3 rounded-xl border border-gray-100 px-3 py-2 hover:bg-gray-50 transition-colors group"
-              >
-                <div className="min-w-0">
-                  <p className="text-xs text-gray-700 truncate group-hover:text-gray-900">
-                    {c.title}
-                  </p>
-                  <p className="text-xs text-gray-400 mt-0.5">{c.condition}</p>
-                </div>
-                <p className="text-sm font-medium text-gray-900 shrink-0">
-                  {fmt(c.price)}
-                </p>
-              </a>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {pricing.comparables.length === 0 && (
-        <p className="text-xs text-gray-400 italic">
-          No live comparables — price based on model prediction only.
-        </p>
-      )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 
-function PricingSpinner() {
+function PricingPanelSkeleton() {
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-5 space-y-3 shadow-sm">
-      <p className="text-xs font-medium uppercase tracking-wide text-gray-400">
-        Pricing your item…
-      </p>
-      <div className="flex items-center gap-2">
-        <div className="h-2 w-2 rounded-full bg-gray-300 animate-bounce [animation-delay:0ms]" />
-        <div className="h-2 w-2 rounded-full bg-gray-300 animate-bounce [animation-delay:150ms]" />
-        <div className="h-2 w-2 rounded-full bg-gray-300 animate-bounce [animation-delay:300ms]" />
-      </div>
-      <p className="text-xs text-gray-400">Searching eBay comparables…</p>
-    </div>
+    <Card>
+      <CardContent className="p-5 space-y-4">
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-32" />
+          <Skeleton className="h-8 w-24" />
+        </div>
+        <Skeleton className="h-2 w-full" />
+        <div className="flex justify-between">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <p className="text-xs text-muted-foreground">Searching eBay comparables…</p>
+      </CardContent>
+    </Card>
   );
 }
+
+/* ── Listing status panel ───────────────────────────────────────────── */
 
 function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
-  const statusConfig = {
-    publishing: {
-      label: "Publishing to eBay…",
-      color: "bg-amber-50 border-amber-200 text-amber-700",
-      icon: (
-        <div className="flex items-center gap-1.5">
-          <div className="h-2 w-2 rounded-full bg-amber-400 animate-pulse" />
-          <span className="text-xs font-medium">In progress</span>
-        </div>
-      ),
-    },
-    live: {
-      label: "Live on eBay",
-      color: "bg-emerald-50 border-emerald-200 text-emerald-700",
-      icon: (
-        <div className="flex items-center gap-1.5">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-          </svg>
-          <span className="text-xs font-medium">Active</span>
-        </div>
-      ),
-    },
-    ended: {
-      label: "Listing ended",
-      color: "bg-gray-50 border-gray-200 text-gray-500",
-      icon: <span className="text-xs font-medium">Ended</span>,
-    },
-    error: {
-      label: "Publishing failed",
-      color: "bg-rose-50 border-rose-200 text-rose-700",
-      icon: (
-        <div className="flex items-center gap-1.5">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
-          <span className="text-xs font-medium">Error</span>
-        </div>
-      ),
-    },
-    needs_specifics: {
-      label: listing.required_specifics?.length
-        ? `eBay needs more info: ${listing.required_specifics.join(", ")}`
-        : "eBay needs more info",
-      color: "bg-blue-50 border-blue-200 text-blue-700",
-      icon: (
-        <div className="flex items-center gap-1.5">
-          <div className="h-2 w-2 rounded-full bg-blue-400" />
-          <span className="text-xs font-medium">Action required</span>
-        </div>
-      ),
-    },
+  const badgeVariant: Record<string, "success" | "warning" | "destructive" | "info" | "secondary"> = {
+    live: "success",
+    publishing: "warning",
+    error: "destructive",
+    needs_specifics: "info",
+    ended: "secondary",
   };
-
-  // Fallback prevents the page from crashing if the API ever returns a
-  // status that isn't in the union (e.g. after a backend deploy that
-  // adds a new state before the frontend ships).
-  const config = statusConfig[listing.status] ?? {
-    label: `Unknown status: ${listing.status}`,
-    color: "bg-gray-50 border-gray-200 text-gray-500",
-    icon: <span className="text-xs font-medium">—</span>,
+  const labels: Record<string, string> = {
+    live: "Live on eBay",
+    publishing: "Publishing…",
+    error: "Publish failed",
+    needs_specifics: listing.required_specifics?.length
+      ? `eBay needs: ${listing.required_specifics.join(", ")}`
+      : "More info needed",
+    ended: "Listing ended",
   };
 
   return (
-    <div className={`rounded-2xl border p-4 space-y-3 shadow-sm ${config.color}`}>
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium">{config.label}</p>
-        {config.icon}
-      </div>
-
-      {listing.posted_price != null && (
-        <p className="text-xs opacity-75">
-          Listed at <span className="font-medium">{fmt(listing.posted_price)}</span>
-        </p>
-      )}
-
-      {listing.url && (
-        <a
-          href={listing.url}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs font-medium underline underline-offset-2 hover:opacity-80 transition-opacity"
-        >
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101" />
-            <path strokeLinecap="round" strokeLinejoin="round" d="M10.172 13.828a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.102 1.101" />
-          </svg>
-          View on eBay
-        </a>
-      )}
-    </div>
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium">{labels[listing.status] ?? listing.status}</p>
+          <Badge variant={badgeVariant[listing.status] ?? "secondary"}>
+            {listing.status}
+          </Badge>
+        </div>
+        {listing.posted_price != null && (
+          <p className="text-xs text-muted-foreground">
+            Listed at <span className="font-medium text-foreground">{fmt(listing.posted_price)}</span>
+          </p>
+        )}
+        {listing.url && (
+          <a
+            href={listing.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline underline-offset-2"
+          >
+            View on eBay →
+          </a>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
-/* ── Toast notification ────────────────────────────────────────────── */
-
-function Toast({ message, type, onClose }: { message: string; type: "success" | "error" | "info"; onClose: () => void }) {
-  const bg = type === "success" ? "bg-emerald-600" : type === "error" ? "bg-rose-600" : "bg-blue-600";
-
-  useEffect(() => {
-    const t = setTimeout(onClose, 5000);
-    return () => clearTimeout(t);
-  }, [onClose]);
-
-  return (
-    <div className={`fixed top-4 right-4 z-50 ${bg} text-white rounded-xl px-5 py-3 shadow-lg flex items-center gap-3 animate-[slideIn_0.3s_ease-out]`}>
-      <span className="text-sm font-medium">{message}</span>
-      <button onClick={onClose} className="text-white/70 hover:text-white text-lg leading-none">&times;</button>
-    </div>
-  );
-}
-
-/* ── Main page ─────────────────────────────────────────────────────── */
+/* ── Main page ──────────────────────────────────────────────────────── */
 
 function ChatPageInner() {
   const router = useRouter();
@@ -247,60 +185,40 @@ function ChatPageInner() {
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [connectingEbay, setConnectingEbay] = useState(false);
-
-  // eBay connection state
   const [ebayConnected, setEbayConnected] = useState(false);
-  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
-
-  // Pricing state
+  const [toast, setToast] = useState<{ message: string; type: ToastType } | null>(null);
   const [pricingResult, setPricingResult] = useState<PricingResult | null>(null);
   const [pricingPending, setPricingPending] = useState(false);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollAttempts = useRef(0);
-
-  // Listing state
   const [listingStatus, setListingStatus] = useState<ListingStatus | null>(null);
   const [listingPending, setListingPending] = useState(false);
 
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollAttempts = useRef(0);
   const bottomRef = useRef<HTMLDivElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (!localStorage.getItem("token")) {
-      router.push("/login");
-      return;
-    }
+    if (!localStorage.getItem("token")) { router.push("/login"); return; }
     setMessages([{
       role: "assistant",
       content: "Hi! I'm your AI selling assistant. Tell me about an item you'd like to sell — what is it?",
     }]);
-
-    // Check eBay connection status on mount
-    api.ebayStatus()
-      .then((res) => setEbayConnected(res.connected))
-      .catch(() => {}); // Silently fail — not critical
-
-    // Handle eBay OAuth callback query params
-    const ebayParam = searchParams.get("ebay");
-    if (ebayParam === "connected") {
+    api.ebayStatus().then((r) => setEbayConnected(r.connected)).catch(() => {});
+    const p = searchParams.get("ebay");
+    if (p === "connected") {
       setEbayConnected(true);
-      setToast({ message: "eBay account connected successfully!", type: "success" });
-      // Clean up the URL without reloading
+      setToast({ message: "eBay account connected!", type: "success" });
       window.history.replaceState({}, "", "/chat");
-    } else if (ebayParam === "declined") {
-      setToast({ message: "eBay connection was declined. You can try again anytime.", type: "info" });
+    } else if (p === "declined") {
+      setToast({ message: "eBay connection declined.", type: "info" });
       window.history.replaceState({}, "", "/chat");
-    } else if (ebayParam === "error") {
-      setToast({ message: "Something went wrong connecting to eBay. Please try again.", type: "error" });
+    } else if (p === "error") {
+      setToast({ message: "eBay connection error. Try again.", type: "error" });
       window.history.replaceState({}, "", "/chat");
     }
   }, [router, searchParams]);
 
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
-  // Cleanup polling on unmount
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages]);
   useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
 
   const startPolling = useCallback((id: string) => {
@@ -309,7 +227,7 @@ function ChatPageInner() {
     setPricingPending(true);
 
     pollRef.current = setInterval(async () => {
-      pollAttempts.current += 1;
+      pollAttempts.current++;
       if (pollAttempts.current > MAX_POLL_ATTEMPTS) {
         clearInterval(pollRef.current!);
         setPricingPending(false);
@@ -317,29 +235,21 @@ function ChatPageInner() {
         return;
       }
       try {
-        // Poll pricing
         if (!pricingResult) {
           const result = await api.getPricing(id);
           if (result) {
             setPricingPending(false);
             setPricingResult(result);
-            // Pricing done → now start watching for listing status
             setListingPending(true);
           }
         }
-
-        // Poll listing status (runs after pricing completes)
         const ls = await api.getListingStatus(id);
         if (ls) {
           setListingStatus(ls);
-          // When the publisher parks the item awaiting more info, surface
-          // the question in the chat so the seller has something to reply
-          // to. Their next message hits /agent/intake/message, which routes
-          // through `_plan_next_step` and continues the flow naturally.
           if (ls.status === "needs_specifics") {
             const next = ls.required_specifics?.[0];
             if (next) {
-              const promptText = `To finish publishing on eBay I just need the ${next} of your item — could you tell me?`;
+              const promptText = `To finish publishing on eBay I just need the ${next} — could you tell me?`;
               setMessages((prev) =>
                 prev.length > 0 && prev[prev.length - 1].content === promptText
                   ? prev
@@ -347,22 +257,12 @@ function ChatPageInner() {
               );
             }
           }
-          if (
-            ls.status === "live" ||
-            ls.status === "error" ||
-            ls.status === "ended" ||
-            ls.status === "needs_specifics"
-          ) {
+          if (["live","error","ended","needs_specifics"].includes(ls.status)) {
             setListingPending(false);
-            // If listing is live/error/ended and pricing is also done, stop polling
-            if (!pricingPending) {
-              clearInterval(pollRef.current!);
-            }
+            if (!pricingPending) clearInterval(pollRef.current!);
           }
         }
-      } catch {
-        // swallow — keep polling
-      }
+      } catch { /* keep polling */ }
     }, POLL_INTERVAL_MS);
   }, [pricingResult, pricingPending]);
 
@@ -372,7 +272,7 @@ function ChatPageInner() {
       const { authorization_url } = await api.ebayConnect();
       window.location.href = authorization_url;
     } catch (err: unknown) {
-      setToast({ message: err instanceof Error ? err.message : "Failed to start eBay connection", type: "error" });
+      setToast({ message: err instanceof Error ? err.message : "Failed", type: "error" });
       setConnectingEbay(false);
     }
   }
@@ -381,22 +281,14 @@ function ChatPageInner() {
     e.preventDefault();
     const content = input.trim();
     if (!content || loading) return;
-
     setInput("");
     setMessages((prev) => [...prev, { role: "user", content }]);
     setLoading(true);
-
     try {
       const reply = await api.sendMessage(content, itemId);
       if (reply.item_id) setItemId(reply.item_id);
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: reply.content, needsImage: reply.needs_image },
-      ]);
-      // Intake just finished — start polling for pricing
-      if (reply.intake_complete && reply.item_id) {
-        startPolling(reply.item_id);
-      }
+      setMessages((prev) => [...prev, { role: "assistant", content: reply.content, needsImage: reply.needs_image }]);
+      if (reply.intake_complete && reply.item_id) startPolling(reply.item_id);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Error";
       setMessages((prev) => [...prev, { role: "assistant", content: `⚠ ${msg}` }]);
@@ -408,22 +300,15 @@ function ChatPageInner() {
   async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file || !itemId) return;
-
     setUploading(true);
     const localUrl = URL.createObjectURL(file);
     setMessages((prev) => [...prev, { role: "user", content: "", imageUrl: localUrl }]);
-
     try {
       await api.uploadImage(file, itemId);
       const reply = await api.sendMessage("I've uploaded the image.", itemId);
       if (reply.item_id) setItemId(reply.item_id);
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: reply.content, needsImage: reply.needs_image },
-      ]);
-      if (reply.intake_complete && reply.item_id) {
-        startPolling(reply.item_id);
-      }
+      setMessages((prev) => [...prev, { role: "assistant", content: reply.content, needsImage: reply.needs_image }]);
+      if (reply.intake_complete && reply.item_id) startPolling(reply.item_id);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Upload failed";
       setMessages((prev) => [...prev, { role: "assistant", content: `⚠ ${msg}` }]);
@@ -433,191 +318,107 @@ function ChatPageInner() {
     }
   }
 
-  function logout() {
-    localStorage.clear();
-    router.push("/login");
-  }
-
   const showPricingPanel = pricingResult !== null || pricingPending;
   const showListingPanel = listingStatus !== null || listingPending;
 
-  return (
-    <div className="flex h-screen bg-gray-50">
-      {/* Toast notification */}
-      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
-
-      {/* Sidebar */}
-      <aside className="w-56 bg-white border-r border-gray-200 flex flex-col p-4 gap-3 shrink-0">
-        <p className="font-semibold text-sm">SalesRep</p>
-        <nav className="space-y-1 mt-4">
-          <Link
-            href="/chat"
-            className="block w-full text-left text-sm bg-blue-50 text-blue-700 font-medium rounded-lg px-3 py-2 transition-colors"
-          >
-            Chat
-          </Link>
-          <Link
-            href="/inbox"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Inbox
-          </Link>
-          <Link
-            href="/settings"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Settings
-          </Link>
-        </nav>
-
-        <div className="flex-1" />
-
-        {/* eBay connection button / status */}
-        {ebayConnected ? (
-          <div className="w-full text-sm bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-lg px-3 py-2 flex items-center gap-2">
-            <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-            </svg>
-            <span>eBay Connected</span>
-          </div>
-        ) : (
-          <button
-            onClick={handleConnectEbay}
-            disabled={connectingEbay}
-            className="w-full text-sm bg-blue-600 text-white rounded-lg px-3 py-2 hover:bg-blue-700 disabled:opacity-50 transition-colors"
-          >
-            {connectingEbay ? "Redirecting…" : "Connect eBay"}
-          </button>
-        )}
-
-        <button
-          onClick={logout}
-          className="w-full text-left text-sm text-gray-400 hover:text-gray-700 px-1 transition-colors"
-        >
-          Log out
-        </button>
-      </aside>
-
-      {/* Chat */}
-      <main className="flex-1 flex flex-col min-w-0">
-        <div className="flex-1 overflow-y-auto px-6 py-6 space-y-4">
-          {messages.map((m, i) => (
-            <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
-              <div className="max-w-lg space-y-2">
-                {m.imageUrl && (
-                  <div className="flex justify-end">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={m.imageUrl}
-                      alt="uploaded"
-                      className="max-h-48 rounded-xl border border-gray-200 object-cover"
-                    />
-                  </div>
-                )}
-                {m.content && (
-                  <div
-                    className={`rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
-                      m.role === "user"
-                        ? "bg-gray-900 text-white rounded-br-sm"
-                        : "bg-white border border-gray-200 text-gray-800 rounded-bl-sm"
-                    }`}
-                  >
-                    {m.content}
-                  </div>
-                )}
-                {m.needsImage && (
-                  <div className="flex justify-start">
-                    <button
-                      onClick={() => fileRef.current?.click()}
-                      disabled={uploading || !itemId}
-                      className="flex items-center gap-2 text-sm bg-gray-100 hover:bg-gray-200 border border-gray-200 rounded-xl px-4 py-2 disabled:opacity-50 transition-colors"
-                    >
-                      {uploading ? "Uploading…" : "📷 Upload photo"}
-                    </button>
-                  </div>
-                )}
-              </div>
-            </div>
-          ))}
-
-          {(loading || uploading) && (
-            <div className="flex justify-start">
-              <div className="bg-white border border-gray-200 rounded-2xl rounded-bl-sm px-4 py-2.5 text-sm text-gray-400">
-                …
-              </div>
-            </div>
-          )}
-          <div ref={bottomRef} />
+  const panel = (showPricingPanel || showListingPanel) ? (
+    <div className="space-y-6">
+      {showPricingPanel && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">Pricing</p>
+          {pricingPending && !pricingResult ? <PricingPanelSkeleton /> : null}
+          {pricingResult ? <PricingPanel pricing={pricingResult} /> : null}
         </div>
-
-        <input
-          ref={fileRef}
-          type="file"
-          accept="image/jpeg,image/png,image/gif,image/webp"
-          className="hidden"
-          onChange={handleFileChange}
-        />
-
-        <form
-          onSubmit={sendMessage}
-          className="border-t border-gray-200 bg-white px-6 py-4 flex gap-3"
-        >
-          <input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Describe what you want to sell…"
-            className="flex-1 border border-gray-200 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-          />
-          <button
-            type="submit"
-            disabled={loading || uploading || !input.trim()}
-            className="bg-gray-900 text-white rounded-xl px-4 py-2 text-sm font-medium hover:bg-gray-700 disabled:opacity-40 transition-colors"
-          >
-            Send
-          </button>
-        </form>
-      </main>
-
-      {/* Pricing + Listing panel — slides in once intake completes */}
-      {(showPricingPanel || showListingPanel) && (
-        <aside className="w-80 shrink-0 bg-gray-50 border-l border-gray-200 p-5 overflow-y-auto space-y-6">
-          {/* Pricing section */}
-          {showPricingPanel && (
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-gray-400 mb-4">
-                Pricing
-              </p>
-              {pricingPending && !pricingResult && <PricingSpinner />}
-              {pricingResult && <PricingPanel pricing={pricingResult} />}
-            </div>
-          )}
-
-          {/* Listing section */}
-          {(showListingPanel || listingStatus) && (
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-gray-400 mb-4">
-                Listing
-              </p>
-              {listingPending && !listingStatus && (
-                <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
-                  <div className="flex items-center gap-2">
-                    <div className="h-2 w-2 rounded-full bg-gray-300 animate-pulse" />
-                    <p className="text-xs text-gray-400">Preparing eBay listing…</p>
-                  </div>
-                </div>
-              )}
-              {listingStatus && <ListingStatusPanel listing={listingStatus} />}
-            </div>
-          )}
-        </aside>
+      )}
+      {showListingPanel && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">Listing</p>
+          {listingPending && !listingStatus ? (
+            <Card><CardContent className="p-4"><Skeleton className="h-4 w-40" /></CardContent></Card>
+          ) : null}
+          {listingStatus ? <ListingStatusPanel listing={listingStatus} /> : null}
+        </div>
       )}
     </div>
+  ) : undefined;
+
+  return (
+    <>
+      {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+      <AppShell
+        panel={panel}
+        ebayConnected={ebayConnected}
+        onConnectEbay={handleConnectEbay}
+        connectingEbay={connectingEbay}
+      >
+        {/* Messages */}
+        <div className="flex flex-col h-screen">
+          <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-6 space-y-4">
+            {messages.map((m, i) => (
+              <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+                <div className="max-w-lg space-y-2">
+                  {m.imageUrl && (
+                    <div className="flex justify-end">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={m.imageUrl} alt="upload" className="max-h-48 rounded-xl border border-border object-cover" />
+                    </div>
+                  )}
+                  {m.content && (
+                    <div className={`rounded-2xl px-4 py-2.5 text-sm leading-relaxed ${
+                      m.role === "user"
+                        ? "bg-primary text-primary-foreground rounded-br-sm"
+                        : "bg-card border border-border text-foreground rounded-bl-sm"
+                    }`}>
+                      {m.content}
+                    </div>
+                  )}
+                  {m.needsImage && (
+                    <div className="flex justify-start">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => fileRef.current?.click()}
+                        disabled={uploading || !itemId}
+                      >
+                        <Camera size={14} />
+                        {uploading ? "Uploading…" : "Upload photo"}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+            {(loading || uploading) && (
+              <div className="flex justify-start">
+                <div className="bg-card border border-border rounded-2xl rounded-bl-sm px-4 py-2.5 text-sm text-muted-foreground">…</div>
+              </div>
+            )}
+            <div ref={bottomRef} />
+          </div>
+
+          <input ref={fileRef} type="file" accept="image/jpeg,image/png,image/gif,image/webp" className="hidden" onChange={handleFileChange} />
+
+          <form onSubmit={sendMessage} className="border-t border-border bg-card px-4 sm:px-6 py-4 flex gap-3">
+            <Input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Describe what you want to sell…"
+              className="flex-1 h-10"
+            />
+            <Button type="submit" disabled={loading || uploading || !input.trim()} size="sm">
+              <Send size={14} />
+              <span className="hidden sm:inline">Send</span>
+            </Button>
+          </form>
+        </div>
+      </AppShell>
+    </>
   );
 }
 
 export default function ChatPage() {
   return (
-    <Suspense fallback={<div className="flex h-screen items-center justify-center bg-gray-50 text-gray-400">Loading…</div>}>
+    <Suspense fallback={<div className="flex h-screen items-center justify-center text-muted-foreground">Loading…</div>}>
       <ChatPageInner />
     </Suspense>
   );

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2,13 +2,39 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 0 0% 98%;
+    --foreground: 222 47% 11%;
+    --card: 0 0% 100%;
+    --card-foreground: 222 47% 11%;
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 222 47% 11%;
+    --primary: 222 47% 11%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 210 40% 96%;
+    --muted-foreground: 215 16% 47%;
+    --accent: 210 40% 96%;
+    --accent-foreground: 222 47% 11%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --radius: 0.75rem;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+}
+
 @keyframes slideIn {
-  from {
-    opacity: 0;
-    transform: translateX(1rem);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(0);
-  }
+  from { opacity: 0; transform: translateX(1rem); }
+  to   { opacity: 1; transform: translateX(0); }
 }

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -2,121 +2,91 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { api, DraftMessage } from "@/lib/api";
+import { AppShell } from "@/components/AppShell";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 function formatRelativeTime(dateString: string) {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
-
-  if (diffInSeconds < 60) return "just now";
-  const diffInMinutes = Math.floor(diffInSeconds / 60);
-  if (diffInMinutes < 60) return `${diffInMinutes} min ago`;
-  const diffInHours = Math.floor(diffInMinutes / 60);
-  if (diffInHours < 24) return `${diffInHours} hr ago`;
-  const diffInDays = Math.floor(diffInHours / 24);
-  return `${diffInDays} day${diffInDays > 1 ? "s" : ""} ago`;
+  const diff = Math.floor((Date.now() - new Date(dateString).getTime()) / 1000);
+  if (diff < 60) return "just now";
+  const m = Math.floor(diff / 60);
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} hr ago`;
+  return `${Math.floor(h / 24)} day${Math.floor(h / 24) > 1 ? "s" : ""} ago`;
 }
 
-function DraftItem({
-  draft,
-  onRemove,
-}: {
-  draft: DraftMessage;
-  onRemove: (id: string) => void;
-}) {
+function DraftItem({ draft, onRemove }: { draft: DraftMessage; onRemove: (id: string) => void }) {
   const [text, setText] = useState(draft.draft_reply || "");
   const [loading, setLoading] = useState(false);
-
-  const handleApprove = async () => {
-    setLoading(true);
-    try {
-      await api.approveDraft(draft.message_id);
-      onRemove(draft.message_id);
-    } catch (err) {
-      alert("Failed to approve draft");
-      setLoading(false);
-    }
-  };
-
-  const handleSaveAndSend = async () => {
-    if (!text.trim()) return;
-    setLoading(true);
-    try {
-      await api.editDraft(draft.message_id, text);
-      onRemove(draft.message_id);
-    } catch (err) {
-      alert("Failed to send edited draft");
-      setLoading(false);
-    }
-  };
-
-  const handleDismiss = async () => {
-    setLoading(true);
-    try {
-      await api.dismissDraft(draft.message_id);
-      onRemove(draft.message_id);
-    } catch (err) {
-      alert("Failed to dismiss draft");
-      setLoading(false);
-    }
-  };
-
+  const [err, setErr] = useState("");
   const hasEdits = text !== draft.draft_reply;
 
+  async function act(fn: () => Promise<unknown>) {
+    setLoading(true); setErr("");
+    try { await fn(); onRemove(draft.message_id); }
+    catch (e: unknown) { setErr(e instanceof Error ? e.message : "Action failed"); setLoading(false); }
+  }
+
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 p-5 shadow-sm space-y-4">
-      <div className="flex justify-between items-center text-sm">
-        <span className="font-semibold text-gray-900">{draft.buyer_handle}</span>
-        <span className="text-gray-500">{formatRelativeTime(draft.received_at)}</span>
-      </div>
+    <Card>
+      <CardContent className="p-5 space-y-4">
+        <div className="flex justify-between items-center text-sm">
+          <span className="font-semibold">{draft.buyer_handle}</span>
+          <span className="text-muted-foreground text-xs">{formatRelativeTime(draft.received_at)}</span>
+        </div>
 
-      <div className="bg-gray-100 text-gray-800 rounded-2xl rounded-tl-sm px-4 py-3 text-sm">
-        {draft.raw_text}
-      </div>
+        {/* Buyer message */}
+        <div className="bg-muted rounded-2xl rounded-tl-sm px-4 py-3 text-sm text-foreground">
+          {draft.raw_text}
+        </div>
 
-      <div className="space-y-2">
-        <label className="block text-xs font-medium uppercase tracking-wide text-gray-500">
-          Agent Draft Reply
-        </label>
-        <textarea
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          disabled={loading}
-          className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[100px] resize-y"
-          placeholder="Type your reply here..."
-        />
-      </div>
-
-      <div className="flex items-center gap-3 justify-end pt-2">
-        <button
-          onClick={handleDismiss}
-          disabled={loading}
-          className="px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 rounded-xl disabled:opacity-50 transition-colors"
-        >
-          Dismiss
-        </button>
-
-        {hasEdits ? (
-          <button
-            onClick={handleSaveAndSend}
-            disabled={loading || !text.trim()}
-            className="px-4 py-2 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 rounded-xl disabled:opacity-50 transition-colors"
-          >
-            Save & Send
-          </button>
-        ) : (
-          <button
-            onClick={handleApprove}
+        {/* Draft reply editor */}
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Agent Draft Reply</p>
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
             disabled={loading}
-            className="px-4 py-2 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 rounded-xl disabled:opacity-50 transition-colors"
+            placeholder="Type your reply…"
+            className="min-h-[100px]"
+          />
+        </div>
+
+        {err && <p className="text-destructive text-xs">{err}</p>}
+
+        <div className="flex items-center gap-2 justify-end">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={loading}
+            onClick={() => act(() => api.dismissDraft(draft.message_id))}
           >
-            Approve
-          </button>
-        )}
-      </div>
-    </div>
+            Dismiss
+          </Button>
+          {hasEdits ? (
+            <Button
+              size="sm"
+              disabled={loading || !text.trim()}
+              onClick={() => act(() => api.editDraft(draft.message_id, text))}
+            >
+              Save &amp; Send
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              disabled={loading}
+              onClick={() => act(() => api.approveDraft(draft.message_id))}
+            >
+              Approve
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -126,99 +96,57 @@ export default function InboxPage() {
   const [loading, setLoading] = useState(true);
 
   const fetchDrafts = useCallback(async () => {
-    try {
-      const data = await api.getDrafts();
-      setDrafts(data);
-    } catch (err) {
-      console.error("Failed to fetch drafts", err);
-    } finally {
-      setLoading(false);
-    }
+    try { setDrafts(await api.getDrafts()); }
+    catch { /* ignore */ }
+    finally { setLoading(false); }
   }, []);
 
   useEffect(() => {
-    if (!localStorage.getItem("token")) {
-      router.push("/login");
-      return;
-    }
-
+    if (!localStorage.getItem("token")) { router.push("/login"); return; }
     fetchDrafts();
-    const interval = setInterval(fetchDrafts, 10000);
-    return () => clearInterval(interval);
+    const iv = setInterval(fetchDrafts, 10000);
+    return () => clearInterval(iv);
   }, [fetchDrafts, router]);
 
   const handleRemove = (id: string) => {
     setDrafts((prev) => prev.filter((d) => d.message_id !== id));
-    fetchDrafts(); // re-fetch to ensure sync
+    fetchDrafts();
   };
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      {/* Sidebar */}
-      <aside className="w-56 bg-white border-r border-gray-200 flex flex-col p-4 gap-3 shrink-0">
-        <p className="font-semibold text-sm">SalesRep</p>
-        
-        <nav className="space-y-1 mt-4">
-          <Link
-            href="/chat"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Chat
-          </Link>
-          <Link
-            href="/inbox"
-            className="block w-full text-left text-sm bg-blue-50 text-blue-700 font-medium rounded-lg px-3 py-2 transition-colors"
-          >
-            Inbox
-            {drafts.length > 0 && (
-              <span className="ml-2 inline-flex items-center justify-center bg-blue-100 text-blue-700 text-xs font-bold px-2 py-0.5 rounded-full">
-                {drafts.length}
-              </span>
-            )}
-          </Link>
-          <Link
-            href="/settings"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Settings
-          </Link>
-        </nav>
-
-        <div className="flex-1" />
-
-        <button
-          onClick={() => {
-            localStorage.clear();
-            router.push("/login");
-          }}
-          className="w-full text-left text-sm text-gray-400 hover:text-gray-700 px-1 transition-colors"
-        >
-          Log out
-        </button>
-      </aside>
-
-      {/* Main content */}
-      <main className="flex-1 overflow-y-auto px-8 py-8">
+    <AppShell inboxCount={drafts.length}>
+      <div className="px-4 sm:px-8 py-8">
         <div className="max-w-2xl mx-auto space-y-6">
-          <div className="flex items-center justify-between pb-4 border-b border-gray-200">
-            <h1 className="text-xl font-semibold text-gray-900">Pending Approvals</h1>
+          <div className="pb-4 border-b border-border">
+            <h1 className="text-xl font-semibold">Pending Approvals</h1>
+            {drafts.length > 0 && (
+              <p className="text-sm text-muted-foreground mt-1">
+                {drafts.length} draft{drafts.length > 1 ? "s" : ""} waiting for review
+              </p>
+            )}
           </div>
 
           {loading && drafts.length === 0 ? (
-            <div className="text-sm text-gray-500 text-center py-12">Loading drafts...</div>
+            <div className="space-y-4">
+              {[1, 2].map((n) => (
+                <Card key={n}><CardContent className="p-5 space-y-3">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-16 w-full" />
+                  <Skeleton className="h-24 w-full" />
+                </CardContent></Card>
+              ))}
+            </div>
           ) : drafts.length === 0 ? (
-            <div className="text-sm text-gray-500 text-center py-12 bg-white rounded-2xl border border-gray-200 border-dashed">
+            <div className="text-sm text-muted-foreground text-center py-12 border border-dashed border-border rounded-2xl">
               No pending drafts
             </div>
           ) : (
             <div className="space-y-6">
-              {drafts.map((draft) => (
-                <DraftItem key={draft.message_id} draft={draft} onRemove={handleRemove} />
-              ))}
+              {drafts.map((d) => <DraftItem key={d.message_id} draft={d} onRemove={handleRemove} />)}
             </div>
           )}
         </div>
-      </main>
-    </div>
+      </div>
+    </AppShell>
   );
 }

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -3,41 +3,32 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-/**
- * Login/Signup page component.
- *
- * Provides a form for users to log in or sign up, with tab switching
- * between login and signup modes. Stores auth token on success and redirects to chat.
- */
 export default function LoginPage() {
   const router = useRouter();
-  // Current active tab: login or signup
   const [tab, setTab] = useState<"login" | "signup">("login");
-  // Email input value
   const [email, setEmail] = useState("");
-  // Password input value
   const [password, setPassword] = useState("");
-  // Error message to display
   const [error, setError] = useState("");
-  // Loading state during API call
   const [loading, setLoading] = useState(false);
 
-  // Handle form submission for login or signup
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setLoading(true);
     try {
-      // Call appropriate API based on current tab
-      const res = tab === "login"
-        ? await api.login(email, password)
-        : await api.signup(email, password);
-      // Store auth data in localStorage
+      const res =
+        tab === "login"
+          ? await api.login(email, password)
+          : await api.signup(email, password);
       localStorage.setItem("token", res.access_token);
       localStorage.setItem("seller_id", res.seller_id);
-      // Redirect to chat page
-      router.push("/chat");
+      // Route to onboarding if not yet completed, else chat
+      const onboarded = await api.getOnboardingStatus().catch(() => true);
+      router.push(onboarded ? "/chat" : "/onboarding");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -45,60 +36,92 @@ export default function LoginPage() {
     }
   }
 
+  async function enterDemo() {
+    setLoading(true);
+    try {
+      const res = await api.demoLogin();
+      localStorage.setItem("token", res.access_token);
+      localStorage.setItem("seller_id", res.seller_id);
+      router.push("/chat");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Demo unavailable");
+    } finally {
+      setLoading(false);
+    }
+  }
+
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      {/* Centered login/signup card */}
-      <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-200 p-8">
-        {/* App branding */}
-        <h1 className="text-xl font-semibold mb-6 text-center">SalesRep</h1>
+    <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-4 bg-background">
+      <Card className="w-full max-w-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-center text-xl">SalesRep</CardTitle>
+          <p className="text-center text-sm text-muted-foreground">
+            AI-powered eBay selling assistant
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Tab switcher */}
+          <div className="flex rounded-xl overflow-hidden border border-border">
+            {(["login", "signup"] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => { setTab(t); setError(""); }}
+                className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                  tab === t
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-card text-muted-foreground hover:bg-accent"
+                }`}
+              >
+                {t === "login" ? "Log in" : "Sign up"}
+              </button>
+            ))}
+          </div>
 
-        {/* Tab selector for login/signup */}
-        <div className="flex rounded-lg overflow-hidden border border-gray-200 mb-6">
-          {(["login", "signup"] as const).map((t) => (
-            <button
-              key={t}
-              onClick={() => { setTab(t); setError(""); }}
-              className={`flex-1 py-2 text-sm font-medium transition-colors ${
-                tab === t ? "bg-gray-900 text-white" : "bg-white text-gray-500 hover:bg-gray-50"
-              }`}
-            >
-              {t === "login" ? "Log in" : "Sign up"}
-            </button>
-          ))}
-        </div>
+          <form onSubmit={submit} className="space-y-3">
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            {error && <p className="text-destructive text-sm">{error}</p>}
+            <Button type="submit" disabled={loading} className="w-full">
+              {loading ? "…" : tab === "login" ? "Log in" : "Create account"}
+            </Button>
+          </form>
 
-        {/* Login/signup form */}
-        <form onSubmit={submit} className="space-y-4">
-          {/* Email input */}
-          <input
-            type="email"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-          />
-          {/* Password input */}
-          <input
-            type="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
-          />
-          {/* Error message display */}
-          {error && <p className="text-red-500 text-sm">{error}</p>}
-          {/* Submit button */}
-          <button
-            type="submit"
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t border-border" />
+            </div>
+            <div className="relative flex justify-center text-xs uppercase">
+              <span className="bg-card px-2 text-muted-foreground">or</span>
+            </div>
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
             disabled={loading}
-            className="w-full bg-gray-900 text-white rounded-lg py-2 text-sm font-medium hover:bg-gray-700 disabled:opacity-50 transition-colors"
+            className="w-full"
+            onClick={enterDemo}
           >
-            {loading ? "…" : tab === "login" ? "Log in" : "Create account"}
-          </button>
-        </form>
-      </div>
+            Try the live demo
+          </Button>
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-muted-foreground text-center max-w-xs">
+        No credit card required for the free tier. eBay connection needed to list items.
+      </p>
     </div>
   );
 }

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { CheckCircle2, ChevronRight, Link as LinkIcon, Bell, MessageSquare } from "lucide-react";
+import { api, AutonomyLevel } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const STEPS = ["Connect eBay", "Reply settings", "You're ready"] as const;
+
+const AUTONOMY_OPTIONS: { value: AutonomyLevel; label: string; description: string }[] = [
+  {
+    value: "draft",
+    label: "Draft mode",
+    description: "Every reply queued for your approval. Recommended to start.",
+  },
+  {
+    value: "auto_low_risk",
+    label: "Auto low-risk",
+    description: "Auto-send factual answers and polite declines only.",
+  },
+  {
+    value: "full_auto",
+    label: "Full auto",
+    description: "Auto-send all replies except accepting an offer.",
+  },
+];
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [ebayConnected, setEbayConnected] = useState(false);
+  const [connectingEbay, setConnectingEbay] = useState(false);
+  const [autonomy, setAutonomy] = useState<AutonomyLevel>("draft");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!localStorage.getItem("token")) { router.push("/login"); return; }
+    api.ebayStatus().then((s) => setEbayConnected(s.connected)).catch(() => {});
+  }, [router]);
+
+  async function connectEbay() {
+    setConnectingEbay(true);
+    try {
+      const { authorization_url } = await api.ebayConnect();
+      window.location.href = authorization_url;
+    } catch { setConnectingEbay(false); }
+  }
+
+  async function finishOnboarding() {
+    setSaving(true);
+    try {
+      await api.updateSettings({ autonomy_level: autonomy });
+      await api.completeOnboarding();
+      router.push("/chat");
+    } catch {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center px-4 py-12">
+      <div className="w-full max-w-lg space-y-8">
+        {/* Brand */}
+        <div className="text-center">
+          <p className="font-semibold text-lg">SalesRep</p>
+          <p className="text-sm text-muted-foreground mt-1">Set up your account in 2 quick steps</p>
+        </div>
+
+        {/* Step indicator */}
+        <div className="flex items-center justify-center gap-2">
+          {STEPS.map((label, i) => (
+            <div key={label} className="flex items-center gap-2">
+              <div
+                className={cn(
+                  "w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold transition-colors",
+                  i < step
+                    ? "bg-emerald-600 text-white"
+                    : i === step
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground"
+                )}
+              >
+                {i < step ? <CheckCircle2 size={14} /> : i + 1}
+              </div>
+              <span className={cn("text-xs hidden sm:inline", i === step ? "font-medium" : "text-muted-foreground")}>
+                {label}
+              </span>
+              {i < STEPS.length - 1 && <ChevronRight size={14} className="text-muted-foreground mx-1" />}
+            </div>
+          ))}
+        </div>
+
+        {/* Step 0 — eBay connect */}
+        {step === 0 && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <LinkIcon size={18} className="text-primary" />
+                <CardTitle>Connect your eBay account</CardTitle>
+              </div>
+              <CardDescription>
+                SalesRep needs permission to read your inbox and publish listings on your behalf.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {ebayConnected ? (
+                <div className="flex items-center gap-2 text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3">
+                  <CheckCircle2 size={15} className="shrink-0" />
+                  eBay is connected
+                </div>
+              ) : (
+                <Button onClick={connectEbay} disabled={connectingEbay} className="w-full sm:w-auto">
+                  {connectingEbay ? "Redirecting to eBay…" : "Connect eBay"}
+                </Button>
+              )}
+              <div className="flex justify-end pt-2">
+                <Button
+                  variant={ebayConnected ? "default" : "ghost"}
+                  size="sm"
+                  onClick={() => setStep(1)}
+                >
+                  {ebayConnected ? "Continue" : "Skip for now"}
+                  <ChevronRight size={14} />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 1 — autonomy */}
+        {step === 1 && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Bell size={18} className="text-primary" />
+                <CardTitle>How should the agent reply?</CardTitle>
+              </div>
+              <CardDescription>
+                Choose how much of your buyer inbox the agent handles automatically. You can change this any time in Settings.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {AUTONOMY_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={cn(
+                    "block border rounded-xl px-4 py-3 cursor-pointer transition-colors",
+                    autonomy === opt.value
+                      ? "border-primary bg-accent"
+                      : "border-border hover:bg-accent/40"
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="radio"
+                      name="autonomy"
+                      value={opt.value}
+                      checked={autonomy === opt.value}
+                      onChange={() => setAutonomy(opt.value)}
+                      className="accent-primary"
+                    />
+                    <span className="font-medium text-sm">{opt.label}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1 ml-7">{opt.description}</p>
+                </label>
+              ))}
+              <div className="flex justify-between pt-2">
+                <Button variant="ghost" size="sm" onClick={() => setStep(0)}>Back</Button>
+                <Button size="sm" onClick={() => setStep(2)}>
+                  Continue <ChevronRight size={14} />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Step 2 — done */}
+        {step === 2 && (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <MessageSquare size={18} className="text-primary" />
+                <CardTitle>You&apos;re all set!</CardTitle>
+              </div>
+              <CardDescription>
+                Head to the chat to list your first item. The agent will handle buyer messages based on the mode you chose.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <ul className="text-sm text-muted-foreground space-y-1.5">
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 size={13} className="text-emerald-600 shrink-0" />
+                  {ebayConnected ? "eBay account connected" : "eBay connect skipped (connect later in Settings)"}
+                </li>
+                <li className="flex items-center gap-2">
+                  <CheckCircle2 size={13} className="text-emerald-600 shrink-0" />
+                  Reply mode: <span className="font-medium text-foreground capitalize">{autonomy.replace(/_/g, " ")}</span>
+                </li>
+              </ul>
+              <div className="flex justify-between pt-2">
+                <Button variant="ghost" size="sm" onClick={() => setStep(1)}>Back</Button>
+                <Button onClick={finishOnboarding} disabled={saving}>
+                  {saving ? "Saving…" : "Go to chat"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -2,20 +2,15 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
-import {
-  api,
-  AutonomyLevel,
-  DraftStats,
-  RepriceEvent,
-  SellerSettings,
-} from "@/lib/api";
+import { Zap, CreditCard, ExternalLink } from "lucide-react";
+import { api, AutonomyLevel, DraftStats, RepriceEvent, SellerSettings, BillingStatus } from "@/lib/api";
+import { AppShell } from "@/components/AppShell";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 
-const AUTONOMY_OPTIONS: {
-  value: AutonomyLevel;
-  label: string;
-  description: string;
-}[] = [
+const AUTONOMY_OPTIONS: { value: AutonomyLevel; label: string; description: string }[] = [
   {
     value: "draft",
     label: "Draft mode",
@@ -30,38 +25,115 @@ const AUTONOMY_OPTIONS: {
   {
     value: "full_auto",
     label: "Full auto",
-    description:
-      "Auto-send all replies except accepting an offer or escalating to you. Use with care.",
+    description: "Auto-send all replies except accepting an offer. Use with care.",
   },
 ];
 
-function formatGBP(amount: number) {
-  return `£${amount.toFixed(2)}`;
+function formatGBP(n: number) { return `£${n.toFixed(2)}`; }
+function formatDate(iso: string) { return new Date(iso).toLocaleString(); }
+
+function Stat({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-xl bg-muted px-3 py-3 text-center">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold mt-1">{value}</p>
+    </div>
+  );
 }
 
-function formatDateTime(iso: string) {
-  return new Date(iso).toLocaleString();
+/* ── Billing card ───────────────────────────────────────────────────── */
+
+function BillingCard({ billing }: { billing: BillingStatus }) {
+  const [loading, setLoading] = useState(false);
+
+  async function upgrade() {
+    setLoading(true);
+    try {
+      const { url } = await api.createCheckoutSession();
+      window.location.href = url;
+    } catch { setLoading(false); }
+  }
+
+  async function manage() {
+    setLoading(true);
+    try {
+      const { url } = await api.createPortalSession();
+      window.location.href = url;
+    } catch { setLoading(false); }
+  }
+
+  const isPro = billing.plan === "pro";
+  const isActive = billing.subscription_status === "active" || billing.subscription_status === "trialing";
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>Subscription</CardTitle>
+          <Badge variant={isPro && isActive ? "success" : "secondary"}>
+            {isPro ? "Pro" : "Free"}
+          </Badge>
+        </div>
+        <CardDescription>
+          {isPro && isActive
+            ? "You have access to all Pro features."
+            : "Upgrade to Pro for unlimited listings and full automation."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {billing.plan === "pro" && billing.current_period_end && (
+          <p className="text-sm text-muted-foreground">
+            Renews {new Date(billing.current_period_end).toLocaleDateString()}
+          </p>
+        )}
+
+        {isPro ? (
+          <Button variant="outline" size="sm" onClick={manage} disabled={loading}>
+            <ExternalLink size={13} />
+            Manage subscription
+          </Button>
+        ) : (
+          <div className="space-y-3">
+            <ul className="text-sm text-muted-foreground space-y-1">
+              <li className="flex items-center gap-2"><Zap size={12} className="text-amber-500" /> Unlimited listings</li>
+              <li className="flex items-center gap-2"><Zap size={12} className="text-amber-500" /> Full auto-reply mode</li>
+              <li className="flex items-center gap-2"><Zap size={12} className="text-amber-500" /> Automatic stale reprice</li>
+            </ul>
+            <Button onClick={upgrade} disabled={loading} className="w-full sm:w-auto">
+              <CreditCard size={14} />
+              {loading ? "Redirecting…" : "Upgrade to Pro"}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
+
+/* ── Main page ──────────────────────────────────────────────────────── */
 
 export default function SettingsPage() {
   const router = useRouter();
   const [settings, setSettings] = useState<SellerSettings | null>(null);
   const [stats, setStats] = useState<DraftStats | null>(null);
   const [reprices, setReprices] = useState<RepriceEvent[]>([]);
+  const [billing, setBilling] = useState<BillingStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saveMsg, setSaveMsg] = useState<string | null>(null);
 
   const fetchAll = useCallback(async () => {
     try {
-      const [s, stat, hist] = await Promise.all([
+      const [s, stat, hist, bill] = await Promise.all([
         api.getSettings(),
         api.getDraftStats(),
         api.getRepriceHistory(),
+        api.getBillingStatus().catch(() => null),
       ]);
       setSettings(s);
       setStats(stat);
       setReprices(hist);
+      setBilling(bill);
     } catch (err) {
       console.error("Failed to load settings", err);
     } finally {
@@ -70,10 +142,7 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
-    if (!localStorage.getItem("token")) {
-      router.push("/login");
-      return;
-    }
+    if (!localStorage.getItem("token")) { router.push("/login"); return; }
     fetchAll();
   }, [fetchAll, router]);
 
@@ -84,14 +153,13 @@ export default function SettingsPage() {
 
   const handleSave = async () => {
     if (!settings) return;
-    setSaving(true);
-    setSaveMsg(null);
+    setSaving(true); setSaveMsg(null);
     try {
       const updated = await api.updateSettings(settings);
       setSettings(updated);
       setSaveMsg("Saved");
     } catch (err) {
-      setSaveMsg(err instanceof Error ? err.message : "Failed to save");
+      setSaveMsg(err instanceof Error ? err.message : "Failed");
     } finally {
       setSaving(false);
       setTimeout(() => setSaveMsg(null), 3000);
@@ -99,72 +167,45 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="flex h-screen bg-gray-50">
-      <aside className="w-56 bg-white border-r border-gray-200 flex flex-col p-4 gap-3 shrink-0">
-        <p className="font-semibold text-sm">SalesRep</p>
-        <nav className="space-y-1 mt-4">
-          <Link
-            href="/chat"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Chat
-          </Link>
-          <Link
-            href="/inbox"
-            className="block w-full text-left text-sm text-gray-600 hover:bg-gray-50 rounded-lg px-3 py-2 transition-colors"
-          >
-            Inbox
-          </Link>
-          <Link
-            href="/settings"
-            className="block w-full text-left text-sm bg-blue-50 text-blue-700 font-medium rounded-lg px-3 py-2 transition-colors"
-          >
-            Settings
-          </Link>
-        </nav>
-        <div className="flex-1" />
-        <button
-          onClick={() => {
-            localStorage.clear();
-            router.push("/login");
-          }}
-          className="w-full text-left text-sm text-gray-400 hover:text-gray-700 px-1 transition-colors"
-        >
-          Log out
-        </button>
-      </aside>
-
-      <main className="flex-1 overflow-y-auto px-8 py-8">
+    <AppShell>
+      <div className="px-4 sm:px-8 py-8">
         <div className="max-w-3xl mx-auto space-y-8">
-          <header className="pb-4 border-b border-gray-200">
-            <h1 className="text-xl font-semibold text-gray-900">Settings</h1>
+          <header className="pb-4 border-b border-border">
+            <h1 className="text-xl font-semibold">Settings</h1>
           </header>
 
           {loading ? (
-            <div className="text-sm text-gray-500">Loading…</div>
+            <div className="space-y-6">
+              {[1, 2, 3].map((n) => (
+                <Card key={n}><CardContent className="p-6 space-y-3">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-16 w-full" />
+                </CardContent></Card>
+              ))}
+            </div>
           ) : !settings ? (
-            <div className="text-sm text-red-600">Failed to load settings.</div>
+            <p className="text-sm text-destructive">Failed to load settings.</p>
           ) : (
             <>
-              <section className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
-                <div>
-                  <h2 className="font-semibold text-gray-900">
-                    Reply autonomy
-                  </h2>
-                  <p className="text-sm text-gray-500 mt-1">
-                    How much of the buyer-message inbox the agent handles
-                    without your sign-off.
-                  </p>
-                </div>
+              {/* Billing */}
+              {billing && <BillingCard billing={billing} />}
 
-                <div className="space-y-2">
+              {/* Autonomy */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Reply autonomy</CardTitle>
+                  <CardDescription>
+                    How much of the buyer inbox the agent handles without your sign-off.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
                   {AUTONOMY_OPTIONS.map((opt) => (
                     <label
                       key={opt.value}
                       className={`block border rounded-xl px-4 py-3 cursor-pointer transition-colors ${
                         settings.autonomy_level === opt.value
-                          ? "border-blue-500 bg-blue-50"
-                          : "border-gray-200 hover:bg-gray-50"
+                          ? "border-primary bg-accent"
+                          : "border-border hover:bg-accent/40"
                       }`}
                     >
                       <div className="flex items-center gap-3">
@@ -173,175 +214,122 @@ export default function SettingsPage() {
                           name="autonomy"
                           value={opt.value}
                           checked={settings.autonomy_level === opt.value}
-                          onChange={() =>
-                            update({ autonomy_level: opt.value })
-                          }
-                          className="accent-blue-600"
+                          onChange={() => update({ autonomy_level: opt.value })}
+                          className="accent-primary"
                         />
-                        <span className="font-medium text-sm text-gray-900">
-                          {opt.label}
-                        </span>
+                        <span className="font-medium text-sm">{opt.label}</span>
                       </div>
-                      <p className="text-xs text-gray-600 mt-1 ml-7">
-                        {opt.description}
-                      </p>
+                      <p className="text-xs text-muted-foreground mt-1 ml-7">{opt.description}</p>
                     </label>
                   ))}
-                </div>
-              </section>
+                </CardContent>
+              </Card>
 
-              <section className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
-                <div>
-                  <h2 className="font-semibold text-gray-900">
-                    Stale-listing reprice
-                  </h2>
-                  <p className="text-sm text-gray-500 mt-1">
-                    The agent will drop the price on listings nobody has
-                    messaged in a while, up to a hard cap.
-                  </p>
-                </div>
-
-                <div className="grid grid-cols-2 gap-5">
-                  <div>
-                    <label className="block text-xs font-medium uppercase tracking-wide text-gray-500 mb-1">
-                      Stale after (days)
-                    </label>
-                    <input
-                      type="number"
-                      min={1}
-                      max={90}
-                      value={settings.stale_threshold_days}
-                      onChange={(e) =>
-                        update({
-                          stale_threshold_days: Number(e.target.value),
-                        })
-                      }
-                      className="w-full border border-gray-200 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
+              {/* Reprice */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Stale-listing reprice</CardTitle>
+                  <CardDescription>
+                    Automatically drop the price on listings nobody has messaged in a while.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide text-muted-foreground mb-1">
+                        Stale after (days)
+                      </label>
+                      <input
+                        type="number" min={1} max={90}
+                        value={settings.stale_threshold_days}
+                        onChange={(e) => update({ stale_threshold_days: Number(e.target.value) })}
+                        className="w-full border border-input bg-card rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium uppercase tracking-wide text-muted-foreground mb-1">
+                        Max reprices per listing
+                      </label>
+                      <input
+                        type="number" min={0} max={10}
+                        value={settings.max_reprice_count}
+                        onChange={(e) => update({ max_reprice_count: Number(e.target.value) })}
+                        className="w-full border border-input bg-card rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <label className="block text-xs font-medium uppercase tracking-wide text-gray-500 mb-1">
-                      Max reprices per listing
-                    </label>
-                    <input
-                      type="number"
-                      min={0}
-                      max={10}
-                      value={settings.max_reprice_count}
-                      onChange={(e) =>
-                        update({
-                          max_reprice_count: Number(e.target.value),
-                        })
-                      }
-                      className="w-full border border-gray-200 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                    />
-                  </div>
-                </div>
-              </section>
+                </CardContent>
+              </Card>
 
+              {/* Save */}
               <div className="flex items-center justify-end gap-4">
                 {saveMsg && (
-                  <span
-                    className={`text-sm ${
-                      saveMsg === "Saved"
-                        ? "text-emerald-600"
-                        : "text-red-600"
-                    }`}
-                  >
+                  <span className={`text-sm ${saveMsg === "Saved" ? "text-emerald-600" : "text-destructive"}`}>
                     {saveMsg}
                   </span>
                 )}
-                <button
-                  onClick={handleSave}
-                  disabled={saving}
-                  className="px-5 py-2 text-sm font-medium bg-gray-900 text-white hover:bg-gray-800 rounded-xl disabled:opacity-50 transition-colors"
-                >
+                <Button onClick={handleSave} disabled={saving}>
                   {saving ? "Saving…" : "Save settings"}
-                </button>
+                </Button>
               </div>
 
+              {/* Draft activity */}
               {stats && (
-                <section className="bg-white rounded-2xl border border-gray-200 p-6">
-                  <h2 className="font-semibold text-gray-900">Draft activity</h2>
-                  <p className="text-sm text-gray-500 mt-1 mb-4">
-                    How often you keep the agent's suggested reply versus
-                    rewriting it.
-                  </p>
-                  <div className="grid grid-cols-4 gap-3 text-center">
-                    <Stat label="Pending" value={stats.pending} />
-                    <Stat label="Approved" value={stats.approved} />
-                    <Stat label="Edited" value={stats.edited} />
-                    <Stat
-                      label="Edit rate"
-                      value={`${Math.round(stats.edit_rate * 100)}%`}
-                    />
-                  </div>
-                </section>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Draft activity</CardTitle>
+                    <CardDescription>How often you keep vs rewrite the agent's suggestions.</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                      <Stat label="Pending"  value={stats.pending} />
+                      <Stat label="Approved" value={stats.approved} />
+                      <Stat label="Edited"   value={stats.edited} />
+                      <Stat label="Edit rate" value={`${Math.round(stats.edit_rate * 100)}%`} />
+                    </div>
+                  </CardContent>
+                </Card>
               )}
 
-              <section className="bg-white rounded-2xl border border-gray-200 p-6">
-                <h2 className="font-semibold text-gray-900">
-                  Reprice history
-                </h2>
-                <p className="text-sm text-gray-500 mt-1 mb-4">
-                  Most recent automatic reprices, newest first.
-                </p>
-                {reprices.length === 0 ? (
-                  <div className="text-sm text-gray-500 text-center py-8 border border-dashed border-gray-200 rounded-xl">
-                    No reprices yet.
-                  </div>
-                ) : (
-                  <ul className="divide-y divide-gray-100">
-                    {reprices.map((r) => (
-                      <li
-                        key={r.id}
-                        className="py-3 flex items-center justify-between text-sm"
-                      >
-                        <div className="min-w-0 flex-1 mr-4">
-                          <p className="font-medium text-gray-900 truncate">
-                            {r.listing_url ? (
-                              <a
-                                href={r.listing_url}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="hover:underline"
-                              >
-                                {r.item_name}
-                              </a>
-                            ) : (
-                              r.item_name
-                            )}
-                          </p>
-                          <p className="text-xs text-gray-500">
-                            {formatDateTime(r.repriced_at)}
-                          </p>
-                        </div>
-                        <div className="text-right shrink-0">
-                          <span className="text-gray-400 line-through mr-2">
-                            {formatGBP(r.old_price)}
-                          </span>
-                          <span className="font-semibold text-gray-900">
-                            {formatGBP(r.new_price)}
-                          </span>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
+              {/* Reprice history */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Reprice history</CardTitle>
+                  <CardDescription>Most recent automatic reprices, newest first.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {reprices.length === 0 ? (
+                    <div className="text-sm text-muted-foreground text-center py-8 border border-dashed border-border rounded-xl">
+                      No reprices yet.
+                    </div>
+                  ) : (
+                    <ul className="divide-y divide-border">
+                      {reprices.map((r) => (
+                        <li key={r.id} className="py-3 flex items-center justify-between text-sm">
+                          <div className="min-w-0 flex-1 mr-4">
+                            <p className="font-medium truncate">
+                              {r.listing_url ? (
+                                <a href={r.listing_url} target="_blank" rel="noreferrer" className="hover:underline">
+                                  {r.item_name}
+                                </a>
+                              ) : r.item_name}
+                            </p>
+                            <p className="text-xs text-muted-foreground">{formatDate(r.repriced_at)}</p>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <span className="text-muted-foreground line-through mr-2">{formatGBP(r.old_price)}</span>
+                            <span className="font-semibold">{formatGBP(r.new_price)}</span>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </CardContent>
+              </Card>
             </>
           )}
         </div>
-      </main>
-    </div>
-  );
-}
-
-function Stat({ label, value }: { label: string; value: number | string }) {
-  return (
-    <div className="rounded-xl bg-gray-50 px-3 py-3">
-      <p className="text-xs uppercase tracking-wide text-gray-500">{label}</p>
-      <p className="text-lg font-semibold text-gray-900 mt-1">{value}</p>
-    </div>
+      </div>
+    </AppShell>
   );
 }

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { MessageSquare, Inbox, Settings, LogOut, Menu, X, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface AppShellProps {
+  children: React.ReactNode;
+  /** Shown in the right-hand panel (e.g. pricing sidebar on /chat). */
+  panel?: React.ReactNode;
+  ebayConnected?: boolean;
+  onConnectEbay?: () => void;
+  connectingEbay?: boolean;
+  inboxCount?: number;
+}
+
+const NAV_ITEMS = [
+  { href: "/chat",     label: "Chat",     Icon: MessageSquare },
+  { href: "/inbox",    label: "Inbox",    Icon: Inbox },
+  { href: "/settings", label: "Settings", Icon: Settings },
+];
+
+export function AppShell({
+  children,
+  panel,
+  ebayConnected,
+  onConnectEbay,
+  connectingEbay,
+  inboxCount,
+}: AppShellProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  function logout() {
+    localStorage.clear();
+    router.push("/login");
+  }
+
+  const sidebar = (
+    <div className="flex flex-col h-full p-4 gap-3">
+      {/* Brand */}
+      <div className="flex items-center justify-between">
+        <p className="font-semibold text-sm">SalesRep</p>
+        {/* Close button — mobile only */}
+        <button
+          className="lg:hidden text-muted-foreground hover:text-foreground"
+          onClick={() => setMobileOpen(false)}
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Nav */}
+      <nav className="space-y-0.5 mt-4">
+        {NAV_ITEMS.map(({ href, label, Icon }) => {
+          const active = pathname === href || pathname.startsWith(href + "/");
+          return (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setMobileOpen(false)}
+              className={cn(
+                "flex items-center gap-2.5 w-full text-sm rounded-lg px-3 py-2 transition-colors",
+                active
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+              )}
+            >
+              <Icon size={15} className="shrink-0" />
+              <span>{label}</span>
+              {label === "Inbox" && inboxCount && inboxCount > 0 ? (
+                <span className="ml-auto inline-flex items-center justify-center bg-primary text-primary-foreground text-xs font-bold px-1.5 py-0.5 rounded-full min-w-[20px]">
+                  {inboxCount}
+                </span>
+              ) : null}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="flex-1" />
+
+      {/* eBay status */}
+      {onConnectEbay !== undefined && (
+        ebayConnected ? (
+          <div className="flex items-center gap-2 text-sm text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2">
+            <CheckCircle2 size={14} className="shrink-0" />
+            <span>eBay Connected</span>
+          </div>
+        ) : (
+          <Button
+            size="sm"
+            onClick={onConnectEbay}
+            disabled={connectingEbay}
+            className="w-full"
+          >
+            {connectingEbay ? "Redirecting…" : "Connect eBay"}
+          </Button>
+        )
+      )}
+
+      {/* Logout */}
+      <button
+        onClick={logout}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground px-1 transition-colors"
+      >
+        <LogOut size={14} />
+        <span>Log out</span>
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="flex h-screen bg-background overflow-hidden">
+      {/* Mobile overlay */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-20 bg-black/40 lg:hidden"
+          onClick={() => setMobileOpen(false)}
+        />
+      )}
+
+      {/* Sidebar — desktop: always visible, mobile: slide-in drawer */}
+      <aside
+        className={cn(
+          "w-56 bg-card border-r border-border shrink-0 z-30",
+          "fixed inset-y-0 left-0 lg:static transition-transform duration-200",
+          mobileOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0"
+        )}
+      >
+        {sidebar}
+      </aside>
+
+      {/* Main area */}
+      <div className="flex flex-1 min-w-0 overflow-hidden">
+        {/* Mobile hamburger */}
+        <button
+          className="absolute top-3 left-3 z-10 lg:hidden text-muted-foreground hover:text-foreground p-1"
+          onClick={() => setMobileOpen(true)}
+        >
+          <Menu size={20} />
+        </button>
+
+        {/* Content */}
+        <main className="flex-1 min-w-0 overflow-y-auto">
+          {children}
+        </main>
+
+        {/* Optional right panel */}
+        {panel && (
+          <aside className="w-80 shrink-0 bg-background border-l border-border p-5 overflow-y-auto hidden xl:block">
+            {panel}
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/Toast.tsx
+++ b/apps/web/components/Toast.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { CheckCircle2, AlertCircle, Info, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ToastType = "success" | "error" | "info";
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+  onClose: () => void;
+}
+
+const config = {
+  success: { bg: "bg-emerald-600", Icon: CheckCircle2 },
+  error:   { bg: "bg-rose-600",    Icon: AlertCircle },
+  info:    { bg: "bg-blue-600",    Icon: Info },
+};
+
+export function Toast({ message, type, onClose }: ToastProps) {
+  const { bg, Icon } = config[type];
+
+  useEffect(() => {
+    const t = setTimeout(onClose, 5000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div
+      className={cn(
+        "fixed top-4 right-4 z-50 flex items-center gap-3 rounded-xl px-5 py-3 shadow-lg",
+        "text-white text-sm font-medium animate-slide-in",
+        bg
+      )}
+    >
+      <Icon size={16} className="shrink-0" />
+      <span>{message}</span>
+      <button onClick={onClose} className="text-white/70 hover:text-white ml-1">
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground",
+        secondary: "bg-secondary text-secondary-foreground",
+        outline: "border border-border text-foreground",
+        success: "bg-emerald-100 text-emerald-700",
+        warning: "bg-amber-100 text-amber-700",
+        destructive: "bg-red-100 text-red-700",
+        info: "bg-blue-100 text-blue-700",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input bg-card hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 px-3 text-xs",
+        lg: "h-11 px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-2xl border border-border bg-card text-card-foreground shadow-sm", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm",
+        "placeholder:text-muted-foreground",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/apps/web/components/ui/skeleton.tsx
+++ b/apps/web/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-xl bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-xl border border-input bg-card px-3 py-2 text-sm",
+        "placeholder:text-muted-foreground resize-y",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -116,6 +116,12 @@ export interface DraftStats {
   edit_rate: number;
 }
 
+export interface BillingStatus {
+  plan: "free" | "pro";
+  subscription_status: "none" | "trialing" | "active" | "past_due" | "canceled";
+  current_period_end: string | null;
+}
+
 export const api = {
   signup: (email: string, password: string) =>
     request<TokenResponse>("/auth/signup", {
@@ -128,6 +134,12 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ email, password }),
     }),
+
+  demoLogin: () =>
+    request<TokenResponse>("/auth/demo"),
+
+  getOnboardingStatus: () =>
+    request<boolean>("/settings/seller/onboarding-status"),
 
   ebayConnect: () =>
     request<{ authorization_url: string }>("/auth/ebay/connect"),
@@ -185,9 +197,22 @@ export const api = {
       body: JSON.stringify(patch),
     }),
 
+  completeOnboarding: () =>
+    request<{ ok: boolean }>("/settings/seller/complete-onboarding", {
+      method: "POST",
+    }),
+
   getRepriceHistory: () =>
     request<RepriceEvent[]>("/listings/reprice-history"),
 
   getDraftStats: () => request<DraftStats>("/conversations/stats"),
+
+  getBillingStatus: () => request<BillingStatus>("/billing/status"),
+
+  createCheckoutSession: () =>
+    request<{ url: string }>("/billing/checkout-session", { method: "POST" }),
+
+  createPortalSession: () =>
+    request<{ url: string }>("/billing/portal-session", { method: "POST" }),
 };
 

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,9 +8,13 @@
       "name": "salesrep-web",
       "version": "0.0.1",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.511.0",
         "next": "^15.3.1",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -1997,6 +2001,32 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
+    "node_modules/lucide-react": {
+      "version": "0.511.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
+      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="
     }
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,9 +8,13 @@
     "start": "next start --port 3000"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.511.0",
     "next": "^15.3.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,8 +1,65 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  content: ["./app/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
-  theme: { extend: {} },
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "slide-in": {
+          from: { opacity: "0", transform: "translateY(-8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "fade-in": {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+      },
+      animation: {
+        "slide-in": "slide-in 0.2s ease-out",
+        "fade-in": "fade-in 0.15s ease-out",
+      },
+    },
+  },
   plugins: [],
 };
 export default config;

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - pip install uv --quiet
       - uv sync --extra dev --no-group dev
-      - npm --prefix apps/web ci
+      - npm --prefix apps/web install
 
   pre_build:
     on-failure: ABORT

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -43,6 +43,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from packages.db.models import (
+    ComparableListing as ComparableListingRow,
+    PricePrediction as PricePredictionRow,
+)
+from packages.ml.registry import get_active_model_version_id
 from packages.agents.pricing.comparable_filter import (
     extract_keywords_from_comparables,
     validate_comparables,
@@ -149,10 +154,10 @@ def _condition_ord(item: Item) -> int:
 
 
 @traceable(name="pricing_model_predict", run_type="tool")
-def _model_predict(item: Item, comparable_prices: list[float]) -> float | None:
+def _model_predict(item: Item, comparable_prices: list[float]) -> tuple[float | None, dict | None]:
     # Calculate the predicted price olely on the historical ML model
     if _MODEL is None or _META is None or _PCA_TITLE is None or _PCA_DESC is None:
-        return None
+        return None, None
 
     st = _get_sentence_model()
 
@@ -230,11 +235,11 @@ def _model_predict(item: Item, comparable_prices: list[float]) -> float | None:
         if cat_bounds:
             pred = float(np.clip(pred, cat_bounds["floor"], cat_bounds["ceiling"]))
 
-        return pred
+        return pred, feat
 
     except Exception:
         logger.exception("v3 prediction failed — falling back to comparable median")
-        return None
+        return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +410,54 @@ async def _collect_comparables(
 # ---------------------------------------------------------------------------
 
 
+async def _persist_prediction(
+    *,
+    item: "Item",
+    seller_id: uuid.UUID,
+    result: "PricingResult",
+    model_pred: float | None,
+    model_features: dict | None,
+    comparable_median: float | None,
+    validated_comparables: list,
+    session: AsyncSession,
+) -> None:
+    """Write a PricePrediction row + ComparableListing rows for the retraining loop."""
+    try:
+        version_id = await get_active_model_version_id(session)
+        prediction = PricePredictionRow(
+            seller_id=seller_id,
+            item_id=item.id,
+            model_version_id=version_id,
+            features=model_features,
+            features_partial=(model_features is None),
+            model_prediction=round(model_pred, 2) if model_pred is not None else None,
+            comparable_median=round(comparable_median, 2) if comparable_median is not None else None,
+            recommended_price=result.recommended_price,
+            min_acceptable_price=result.min_acceptable_price,
+            confidence_score=result.confidence_score,
+        )
+        session.add(prediction)
+        await session.flush()  # get prediction.id without committing
+
+        for c in validated_comparables:
+            session.add(
+                ComparableListingRow(
+                    price_prediction_id=prediction.id,
+                    seller_id=seller_id,
+                    external_item_id=c.item_id,
+                    title=c.title,
+                    price=c.price,
+                    currency=c.currency,
+                    condition=c.condition,
+                    listing_url=c.listing_url,
+                    relevance="validated",
+                )
+            )
+        # The caller (pipeline) commits the session; we just stage the rows.
+    except Exception:
+        logger.exception("[pricing] Failed to persist prediction — continuing without logging")
+
+
 @traceable(name="pricing_agent", run_type="chain")
 async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -> PricingResult:
     """Agent 2 — Pricing (v3 model).
@@ -436,7 +489,7 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
     comparable_median = statistics.median(prices) if prices else None
 
     # Get price prediction from historical ML model
-    model_pred = _model_predict(row, prices)
+    model_pred, model_features = _model_predict(row, prices)
 
     # Weighted average of model prediction and comparable median
     if comparable_median is not None and model_pred is not None:
@@ -487,7 +540,7 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
         for c in validated
     ]
 
-    return PricingResult(
+    result = PricingResult(
         item_id=item_id,
         recommended_price=round(recommended, 2),
         confidence_score=round(confidence, 2),
@@ -496,3 +549,17 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
         price_high=round(price_high, 2),
         comparables=comparables,
     )
+
+    # Phase 6.0 — persist prediction for the retraining loop
+    await _persist_prediction(
+        item=row,
+        seller_id=seller_id,
+        result=result,
+        model_pred=model_pred,
+        model_features=model_features,
+        comparable_median=comparable_median,
+        validated_comparables=validated,
+        session=session,
+    )
+
+    return result

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -436,7 +436,9 @@ async def _persist_prediction(
             features=model_features,
             features_partial=(model_features is None),
             model_prediction=round(model_pred, 2) if model_pred is not None else None,
-            comparable_median=round(comparable_median, 2) if comparable_median is not None else None,
+            comparable_median=round(comparable_median, 2)
+            if comparable_median is not None
+            else None,
             recommended_price=result.recommended_price,
             min_acceptable_price=result.min_acceptable_price,
             confidence_score=result.confidence_score,

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -43,16 +43,17 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from packages.db.models import (
-    ComparableListing as ComparableListingRow,
-    PricePrediction as PricePredictionRow,
-)
-from packages.ml.registry import get_active_model_version_id
 from packages.agents.pricing.comparable_filter import (
     extract_keywords_from_comparables,
     validate_comparables,
 )
-from packages.db.models import Item, ItemCondition
+from packages.db.models import (
+    ComparableListing as ComparableListingRow,
+    Item,
+    ItemCondition,
+    PricePrediction as PricePredictionRow,
+)
+from packages.ml.registry import get_active_model_version_id
 from packages.platform_adapters.ebay.browse import Comparable, get_category_id, search_comparables
 from packages.schemas.agents import ComparableListing, PricingResult
 

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -159,7 +159,7 @@ def _condition_ord(item: Item) -> int:
 
 
 @traceable(name="pricing_model_predict", run_type="tool")
-def _model_predict(item: Item, comparable_prices: list[float]) -> tuple[float | None, dict | None]:
+def _model_predict(item: Item, comparable_prices: list[float]) -> tuple[float | None, dict[str, Any] | None]:
     # Calculate the predicted price olely on the historical ML model
     if _MODEL is None or _META is None or _PCA_TITLE is None or _PCA_DESC is None:
         return None, None
@@ -421,9 +421,9 @@ async def _persist_prediction(
     seller_id: uuid.UUID,
     result: "PricingResult",
     model_pred: float | None,
-    model_features: dict | None,
+    model_features: dict[str, Any] | None,
     comparable_median: float | None,
-    validated_comparables: list,
+    validated_comparables: list[Any],
     session: AsyncSession,
 ) -> None:
     """Write a PricePrediction row + ComparableListing rows for the retraining loop."""

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -49,8 +49,12 @@ from packages.agents.pricing.comparable_filter import (
 )
 from packages.db.models import (
     ComparableListing as ComparableListingRow,
+)
+from packages.db.models import (
     Item,
     ItemCondition,
+)
+from packages.db.models import (
     PricePrediction as PricePredictionRow,
 )
 from packages.ml.registry import get_active_model_version_id

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -159,7 +159,9 @@ def _condition_ord(item: Item) -> int:
 
 
 @traceable(name="pricing_model_predict", run_type="tool")
-def _model_predict(item: Item, comparable_prices: list[float]) -> tuple[float | None, dict[str, Any] | None]:
+def _model_predict(
+    item: Item, comparable_prices: list[float]
+) -> tuple[float | None, dict[str, Any] | None]:
     # Calculate the predicted price olely on the historical ML model
     if _MODEL is None or _META is None or _PCA_TITLE is None or _PCA_DESC is None:
         return None, None

--- a/packages/config.py
+++ b/packages/config.py
@@ -96,6 +96,13 @@ class Settings(BaseSettings):
     langsmith_api_key: str = ""
     langsmith_project: str = "salesrep"
 
+    # ── Stripe billing ─────────────────────────────────────────────────────
+    billing_enabled: bool = False
+    stripe_secret_key: str = ""
+    stripe_webhook_secret: str = ""
+    stripe_price_id_pro: str = ""  # price_xxx from Stripe dashboard
+    stripe_publishable_key: str = ""
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Index,
     Integer,
     Numeric,
     SmallInteger,
@@ -83,6 +84,27 @@ class NegotiationStatus(enum.StrEnum):
     seller_review = "seller_review"  # Agent escalated to seller for approval
 
 
+class ModelStatus(enum.StrEnum):
+    training = "training"
+    shadow = "shadow"
+    active = "active"
+    archived = "archived"
+    failed = "failed"
+
+
+class PlanTier(enum.StrEnum):
+    free = "free"
+    pro = "pro"
+
+
+class SubscriptionStatus(enum.StrEnum):
+    none = "none"
+    trialing = "trialing"
+    active = "active"
+    past_due = "past_due"
+    canceled = "canceled"
+
+
 class AutonomyLevel(enum.StrEnum):
     # Per-seller cap on how much Agent 4 may send without approval.
     draft = "draft"  # Every reply requires seller approval
@@ -117,6 +139,25 @@ class Seller(Base):
     stale_threshold_days: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
     # Hard cap on automatic reprices per listing
     max_reprice_count: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+
+    # Onboarding + demo flags (Phase 7)
+    onboarding_completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_demo: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Stripe billing (Phase 7)
+    stripe_customer_id: Mapped[str | None] = mapped_column(Text)
+    plan: Mapped[PlanTier] = mapped_column(
+        Enum(PlanTier, name="plan_tier"),
+        nullable=False,
+        default=PlanTier.free,
+    )
+    subscription_status: Mapped[SubscriptionStatus] = mapped_column(
+        Enum(SubscriptionStatus, name="subscription_status"),
+        nullable=False,
+        default=SubscriptionStatus.none,
+    )
+    stripe_subscription_id: Mapped[str | None] = mapped_column(Text)
+    current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     # Auto-managed timestamps (DB-side defaults)
     created_at: Mapped[datetime] = mapped_column(
@@ -882,6 +923,118 @@ class EntityMention(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 6.0 — ML retraining loop data capture
+# ---------------------------------------------------------------------------
+
+
+class ModelVersion(Base):
+    """Registry of LightGBM model artifacts."""
+
+    __tablename__ = "model_versions"
+    __table_args__ = (
+        Index(
+            "ix_model_versions_active_unique",
+            "status",
+            unique=True,
+            postgresql_where="status = 'active'",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    version: Mapped[str] = mapped_column(Text, nullable=False)
+    algorithm: Mapped[str] = mapped_column(Text, nullable=False, default="lightgbm")
+    artifact_s3_key: Mapped[str | None] = mapped_column(Text)
+    feature_cols: Mapped[list[Any] | None] = mapped_column(JSONB)
+    train_metrics: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    shadow_metrics: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    training_row_count: Mapped[int | None] = mapped_column(Integer)
+    status: Mapped[ModelStatus] = mapped_column(
+        Enum(ModelStatus, name="model_status"),
+        nullable=False,
+        default=ModelStatus.training,
+    )
+    trained_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    promoted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    predictions: Mapped[list["PricePrediction"]] = relationship(
+        "PricePrediction", back_populates="model_version"
+    )
+
+
+class PricePrediction(Base):
+    """Point-in-time feature snapshot for one Agent 2 pricing decision."""
+
+    __tablename__ = "price_predictions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    seller_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sellers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    item_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("items.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    listing_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("listings.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    model_version_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("model_versions.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+
+    features: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    features_partial: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    model_prediction: Mapped[float | None] = mapped_column(Numeric(12, 2))
+    comparable_median: Mapped[float | None] = mapped_column(Numeric(12, 2))
+    recommended_price: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    min_acceptable_price: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    confidence_score: Mapped[float | None] = mapped_column(Numeric(5, 4))
+    is_shadow: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    realized_sale_price: Mapped[float | None] = mapped_column(Numeric(12, 2))
+    realized_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    model_version: Mapped["ModelVersion | None"] = relationship("ModelVersion", back_populates="predictions")
+    comparables: Mapped[list["ComparableListing"]] = relationship(
+        "ComparableListing", back_populates="prediction", cascade="all, delete-orphan"
+    )
+
+
+class ComparableListing(Base):
+    """Persisted eBay comparable snapshot linked to a pricing prediction."""
+
+    __tablename__ = "comparable_listings"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    price_prediction_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("price_predictions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seller_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sellers.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    external_item_id: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str | None] = mapped_column(Text)
+    price: Mapped[float | None] = mapped_column(Numeric(12, 2))
+    currency: Mapped[str | None] = mapped_column(Text)
+    condition: Mapped[str | None] = mapped_column(Text)
+    listing_url: Mapped[str | None] = mapped_column(Text)
+    relevance: Mapped[str | None] = mapped_column(Text)
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    prediction: Mapped["PricePrediction"] = relationship("PricePrediction", back_populates="comparables")
 
     # Relationships
     buyer_message: Mapped["BuyerMessage"] = relationship(

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -1050,8 +1050,3 @@ class ComparableListing(Base):
     prediction: Mapped["PricePrediction"] = relationship(
         "PricePrediction", back_populates="comparables"
     )
-
-    # Relationships
-    buyer_message: Mapped["BuyerMessage"] = relationship(
-        "BuyerMessage", back_populates="entity_mentions"
-    )

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -982,10 +982,16 @@ class PricePrediction(Base):
         UUID(as_uuid=True), ForeignKey("items.id", ondelete="CASCADE"), nullable=False, index=True
     )
     listing_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("listings.id", ondelete="SET NULL"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("listings.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
     model_version_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("model_versions.id", ondelete="SET NULL"), nullable=True, index=True
+        UUID(as_uuid=True),
+        ForeignKey("model_versions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
 
     features: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
@@ -1002,7 +1008,9 @@ class PricePrediction(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    model_version: Mapped["ModelVersion | None"] = relationship("ModelVersion", back_populates="predictions")
+    model_version: Mapped["ModelVersion | None"] = relationship(
+        "ModelVersion", back_populates="predictions"
+    )
     comparables: Mapped[list["ComparableListing"]] = relationship(
         "ComparableListing", back_populates="prediction", cascade="all, delete-orphan"
     )
@@ -1034,7 +1042,9 @@ class ComparableListing(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    prediction: Mapped["PricePrediction"] = relationship("PricePrediction", back_populates="comparables")
+    prediction: Mapped["PricePrediction"] = relationship(
+        "PricePrediction", back_populates="comparables"
+    )
 
     # Relationships
     buyer_message: Mapped["BuyerMessage"] = relationship(

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -924,6 +924,11 @@ class EntityMention(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
+    # Relationships
+    buyer_message: Mapped["BuyerMessage"] = relationship(
+        "BuyerMessage", back_populates="entity_mentions"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Phase 6.0 — ML retraining loop data capture

--- a/packages/ml/registry.py
+++ b/packages/ml/registry.py
@@ -1,0 +1,46 @@
+"""Minimal model-version registry for Phase 6.0.
+
+The full registry (S3 upload/download, promote, hot-reload) is built in
+Phase 6.2. This module provides only what Agent 2 needs right now:
+get_active_model_version_id() so predictions can be tagged.
+"""
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from packages.db.models import ModelStatus, ModelVersion
+
+logger = logging.getLogger(__name__)
+
+# Simple in-process cache: (model_version_id, cached_at)
+_cached_id: uuid.UUID | None = None
+_cached_at: datetime | None = None
+_CACHE_TTL_SECONDS = 60
+
+
+async def get_active_model_version_id(session: AsyncSession) -> uuid.UUID | None:
+    """Return the id of the currently active ModelVersion, with a 60 s TTL cache."""
+    global _cached_id, _cached_at
+
+    now = datetime.now(UTC)
+    if (
+        _cached_id is not None
+        and _cached_at is not None
+        and (now - _cached_at).total_seconds() < _CACHE_TTL_SECONDS
+    ):
+        return _cached_id
+
+    row = await session.scalar(
+        select(ModelVersion).where(ModelVersion.status == ModelStatus.active)
+    )
+    if row is None:
+        logger.warning("[registry] No active model version found")
+        return None
+
+    _cached_id = row.id
+    _cached_at = now
+    return _cached_id

--- a/phase_6_implementation_plan.md
+++ b/phase_6_implementation_plan.md
@@ -1,0 +1,509 @@
+# Phase 6 — Retraining Loop + Feedback — Implementation Plan
+
+> Companion to **`implementation_plan_v2.md`** § Phase 6. Read that first.
+> **Goal:** the pricing model improves automatically from real outcomes — every
+> Agent 2 pricing decision is captured with its point-in-time feature vector, and
+> when an item actually sells the realized price becomes a training label.
+> A scheduled job retrains LightGBM, evaluates it against the live model, and
+> promotes it only when it measurably wins.
+>
+> **Status when this plan was written (2026-05-15):** Phases 0–5 complete.
+> No prediction logging exists yet — Agent 2 returns a `PricingResult` and the
+> pipeline writes it onto the `items` row; nothing records *how* the price was
+> derived. Closing that gap is the critical path of Phase 6.
+
+---
+
+## 1. Scope & deviations from v2
+
+The v2 plan sketches Phase 6 in seven bullets. Two of them need design decisions
+spelled out before implementation, and one phrase in v2 § 9 is not implementable
+as literally written. These are resolved here.
+
+### 1.1 "Shadow mode (48 h) before promotion" — reconciled
+
+v2 § 9 says a new model runs in shadow for 48 h, then promotes if shadow MAE
+beats the active model. **This cannot work for a pricing model**: the label is
+the *realized sale price*, which arrives days-to-weeks after the prediction. A
+48-hour window yields almost no labelled outcomes.
+
+Phase 6 therefore splits evaluation into two distinct mechanisms:
+
+| Mechanism | Purpose | Timing |
+|-----------|---------|--------|
+| **Time-split backtest** | The **promotion gate**. Train on the oldest 80 % of labelled predictions, score the newest 20 %, compare MAE/R² to the active model on the *same* held-out rows. | Immediate, inside the training job |
+| **Shadow scoring** | **Post-promotion monitoring**, feeds the "MAE regression > 10 %" alert. The active model's recent rolling MAE is tracked as more items sell. | Continuous |
+
+So: promotion is gated by a backtest (deterministic, immediate); shadow rows
+(`price_predictions.is_shadow = true`) are kept for ongoing health monitoring,
+not as a blocking gate.
+
+### 1.2 Retraining re-fits the booster only — PCA and the embedder are frozen
+
+The 78 feature columns include 32 title-PCA + 32 desc-PCA components produced by
+`pca_title_v3.pkl` / `pca_desc_v3.pkl` on top of `all-MiniLM-L6-v2` embeddings.
+Phase 6 **reuses those transformers unchanged** and re-fits only the LightGBM
+booster. Re-fitting PCA would (a) require re-encoding every row and (b) risk
+leakage from fitting the reducer on rows that include the eval set. Changing the
+embedding model or PCA is explicitly out of scope — that is a manual,
+notebook-driven "v5" effort, not part of the automated loop.
+
+### 1.3 Hot-reload via lazy version check, not an event consumer
+
+v2 says `model.promoted` → worker re-reads the artifact. The API process does
+**not** consume SQS or EventBridge, so an event-only mechanism would never reach
+it. Phase 6 uses a **lazy version check**: on each `run()`, Agent 2 cheaply reads
+the active `model_versions.id` (cached ~60 s) and swaps the in-process model if it
+changed. This works identically in the API and the worker with no new consumer.
+`model.promoted` is still emitted, but purely as an observability/alert signal.
+(Once the Fargate worker lands in Phase 7, an event-driven reload becomes clean —
+noted as a future refinement, not built here.)
+
+### 1.4 The bootstrapping problem
+
+The loop produces zero value until enough items have **both** a logged prediction
+**and** a realized sale. A new product has low sale volume, so the first useful
+retrain may be weeks out. Mitigations baked into the plan:
+
+- **6.0** ships first and alone — start accumulating data immediately.
+- A one-time best-effort backfill seeds `price_predictions` from existing
+  `items` that already carry `recommended_price` and have a `sales` row.
+- The training job refuses to run below `ml_min_training_rows` and the v3 model
+  stays active until the backtest gate is genuinely beaten — no regression risk.
+
+---
+
+## 2. Data flow
+
+```
+                   ┌───────────────────────────────────────────────┐
+   Agent 2 run() ──┤ compute 78-feature vector + LightGBM predict   │
+                   │ persist: price_predictions (+ comparable_      │
+                   │ listings) tagged with active model_version_id  │
+                   └───────────────────────────────────────────────┘
+                                      │
+            item eventually sells     ▼
+   Agent 4 confirm_sale ──► sales row (item_id, sale_price, ...)
+                                      │
+   EventBridge cron(0 2 * * ? *) ─────┤
+        POST /internal/train-model    ▼
+                   ┌───────────────────────────────────────────────┐
+   SQS task        │ build_training_dataframe():                    │
+   train_pricing_  │   price_predictions ⋈ sales  (label = price)   │
+   model           │   + avg_offer_ratio_in_category from           │
+                   │     offer_signals                              │
+                   │   time-split 80/20, leakage guard              │
+                   │ train LightGBM booster (PCA frozen)            │
+                   │ backtest: new vs active MAE/R² on test slice   │
+                   │ if new MAE ≤ active MAE × 0.98 AND R² > 0.65:  │
+                   │   upload artifacts to S3, register version,    │
+                   │   flip status active, emit model.promoted      │
+                   └───────────────────────────────────────────────┘
+                                      │
+   next Agent 2 run() ── lazy version check ──► downloads + swaps model
+
+   EventBridge cron(0 3 ? * SUN *) ─► /internal/optuna-search
+        ─► SQS task optuna_search ─► same pipeline, Optuna-tuned params
+```
+
+---
+
+## 3. Sub-phase breakdown
+
+Ordered by dependency. **6.0 is the critical path** — until predictions are
+logged, no training data exists, so every day 6.0 slips is a lost day of data.
+
+### 6.0 — Schema + prediction capture (ship first, on its own)
+
+**Migration `0013_phase6_ml_tables.py`** — three tables (full DDL in § 4):
+- [ ] `model_versions` — model artifact registry (global, no `seller_id`)
+- [ ] `price_predictions` — one row per Agent 2 decision; point-in-time feature snapshot
+- [ ] `comparable_listings` — persisted comparable snapshots per prediction
+- [ ] Seed row: insert the current **v3** model as `model_versions(status='active')`
+- [ ] RLS policies for `price_predictions` and `comparable_listings`
+      (mirror `0002_rls_policies.py`); `model_versions` is global — no RLS
+- [ ] ORM models in `packages/db/models.py`: `ModelVersion`, `PricePrediction`,
+      `ComparableListing`, plus a `ModelStatus` StrEnum
+- [ ] Register the new model modules in `alembic/env.py` import block
+
+**Instrument Agent 2 (`packages/agents/pricing/agent.py`):**
+- [ ] Refactor `_model_predict` to return both the prediction **and** the 78-key
+      feature dict it built (currently it returns only `float | None`)
+- [ ] In `run()`, after the price is finalised, write one `PricePrediction` row:
+      `features` JSONB, `model_prediction`, `comparable_median`,
+      `recommended_price`, `min_acceptable_price`, `confidence_score`,
+      `model_version_id` = active version
+- [ ] Persist the validated comparables as `ComparableListing` rows linked to
+      that prediction (this supersedes the ad-hoc `items.pricing_comparables`
+      JSONB for training use; v2 § Phase 2 deferred these tables to here)
+- [ ] When the item is later published, set `price_predictions.listing_id`
+      (small update in the publisher or pipeline node)
+- [ ] Graceful no-op when `_MODEL is None` — comparable-only pricing still works,
+      it just produces no training row
+
+**Tests:**
+- [ ] Integration: `run()` with respx-mocked eBay writes exactly one
+      `price_predictions` row + N `comparable_listings` rows
+- [ ] The stored `features` dict has all 78 keys from `meta["feature_cols"]`
+
+**Deliverable:** every pricing decision in prod is now durably logged with the
+features that produced it. Nothing else in Phase 6 can start without this.
+
+---
+
+### 6.0a — One-time historical backfill (optional, do soon after 6.0)
+
+- [ ] Script `scripts/backfill_price_predictions.py`: for each `sales` row whose
+      `item` has `recommended_price` set but no `price_predictions` row,
+      synthesize a best-effort prediction row. Embedding/PCA features are
+      recomputable from `item.name`/`item.description`; comparable stats come
+      from `items.pricing_comparables` if present, else flagged
+      `features_partial = true` and excluded from training
+- [ ] Idempotent (skip items already having a prediction row)
+
+This is best-effort — it gives the first retrain *some* signal instead of zero.
+
+---
+
+### 6.1 — Training dataset builder
+
+**New module `packages/ml/dataset.py`:**
+- [ ] `build_training_dataframe(session) -> pandas.DataFrame`
+  - Join non-shadow `price_predictions` ⋈ `sales` on `item_id`; label = `sale_price`
+  - Reconstruct the feature matrix from `price_predictions.features` JSONB
+  - **Leakage guard:**
+    - Drop rows with incomplete features (`features_partial` / missing keys)
+    - Drop rows where `sale_price` is implausible vs `recommended_price`
+      (ratio outside e.g. [0.2, 5.0]) — data-entry / wrong-join defence
+    - Never recompute comparable stats "as of now" — only the stored snapshot
+      is used (recomputing would inject post-prediction market information)
+    - Exclude the model's own `model_prediction` from the feature set
+  - Backfill `price_predictions.realized_sale_price` / `realized_at` as an
+    idempotent side effect (keeps the dashboard query in 6.8 cheap)
+- [ ] `avg_offer_ratio_in_category` feature: aggregate over `offer_signals`
+      joined `buyer_messages → conversations → listings → items` →
+      `mean(offer.amount / listing.posted_price)` grouped by `items.category`.
+      It is a pure function of category + the offer table, so it can be joined
+      onto every training row deterministically (no per-row snapshot needed) and
+      onto old prediction rows too. For inference it is baked into
+      `meta["inference_encodings"]` as a `category → ratio` map, exactly like the
+      existing `brand_enc` / `category_enc`. (First iteration uses the global
+      map; an expanding-window variant — only offers dated before each row — is
+      noted as a later refinement.)
+
+**Tests:**
+- [ ] Builder returns the expected columns; leakage-guard rows are dropped
+- [ ] `avg_offer_ratio_in_category` computed correctly on a seeded fixture
+
+---
+
+### 6.2 — Training job + model registry
+
+**New module `packages/ml/train.py`:**
+- [ ] `train_pricing_model(df, params) -> TrainResult` — re-fit the LightGBM
+      booster (PCA + embedder frozen), log-price target as today
+- [ ] Chronological 80/20 split on `price_predictions.created_at` — **never** a
+      random split (random split leaks future market conditions into train)
+- [ ] Compute `mae`, `rmse`, `r2`, `within_20_pct` on the 20 % test slice
+- [ ] Re-score the **same** test slice with the current active model for an
+      apples-to-apples comparison
+
+**New module `packages/ml/registry.py`:**
+- [ ] `get_active_model_version(session) -> ModelVersion`
+- [ ] `register_version(...)` — insert a `model_versions` row (`status='shadow'`)
+- [ ] `promote(version_id)` — flip the new row to `active`, the old one to
+      `archived`, set `promoted_at` (single transaction; partial unique index
+      keeps exactly one `active`)
+- [ ] `upload_artifacts(version, paths)` / `download_artifacts(version) -> paths`
+      — S3 bundle = `model.pkl` + `pca_title.pkl` + `pca_desc.pkl` + `meta.json`
+      under `s3://{ml_artifact_bucket}/{ml_artifact_prefix}/{version}/`
+
+**Promotion gate** (reconciles v2 § 5 "≥ 2 %" with v2 § 9 "R² > 0.65"):
+- [ ] Promote **iff** `mae_new ≤ mae_active × (1 - ml_promotion_mae_improvement)`
+      **AND** `r2_new > ml_promotion_min_r2`
+- [ ] Refuse to train at all below `ml_min_training_rows` — log + skip cleanly
+- [ ] On promotion: write artifacts to S3, `promote()`, emit `model.promoted`
+- [ ] On rejection: keep the candidate row as `status='archived'` with metrics
+      recorded (so model history is auditable), active model untouched
+
+**Bootstrap (one-time, part of this sub-phase):** upload the existing v3
+`.pkl` artifacts to S3 and point the seed `model_versions` v3 row at that key.
+This also **fixes a current fragility** — v3 `.pkl` files are git-ignored
+(`*.pkl` in `.gitignore`), so prod currently relies on artifacts being placed on
+the host by hand. After 6.2, S3 is the single source of truth.
+
+**SQS task (`workers/sqs_worker.py`):**
+- [ ] Register `train_pricing_model` — thin wrapper:
+      `build_training_dataframe → train → gate → register/promote`
+- [ ] Heavy-import discipline: `lightgbm` / `pandas` imported inside the handler,
+      not at module top level (keeps the API process light)
+
+**Internal endpoint (`apps/api/routers/internal.py`):**
+- [ ] `POST /internal/train-model` — `X-Internal-Key` guarded; enqueues the
+      `train_pricing_model` SQS task; logs-and-skips if `SQS_QUEUE_URL` unset
+      (same fallback pattern as `/check-stale-listings`)
+
+**Tests:**
+- [ ] Gate logic: promotes on ≥ 2 % MAE win + R² > 0.65; rejects each failure
+      mode; skips below the row floor
+- [ ] Time-split is strictly chronological
+- [ ] Registry: `promote()` leaves exactly one `active` row
+- [ ] Integration: full job on a seeded synthetic dataset registers a version
+
+---
+
+### 6.3 — Model hot-reload
+
+**`packages/agents/pricing/agent.py`:**
+- [ ] Replace import-time local-file loading with registry-driven loading:
+      resolve the active `model_versions` row → download the S3 bundle to a local
+      cache dir (e.g. `packages/ml/cache/{version}/`) → load
+- [ ] At the start of `run()`, check the active `model_versions.id`; if it
+      differs from the loaded version, download + atomically swap the module
+      globals (`_MODEL`, `_META`, `_PCA_TITLE`, `_PCA_DESC`)
+- [ ] Throttle the check with an in-process TTL (`ml_model_reload_check_seconds`,
+      default 60) so it is not a DB round-trip on every pricing call
+- [ ] Fallback chain unchanged: if no artifact is reachable, comparable-only
+      pricing still works
+
+**Tests:**
+- [ ] Promoting a new version causes the next `run()` to load it
+- [ ] TTL prevents a DB hit on every call
+
+---
+
+### 6.4 — Optuna weekly hyperparameter search
+
+- [ ] SQS task `optuna_search` — same dataset + time-split, Optuna objective =
+      test-slice MAE, `n_trials = optuna_n_trials` (default 40 — minutes on a
+      t3.medium for a few-thousand-row LightGBM fit)
+- [ ] Best params flow straight into `train_pricing_model`'s training step; the
+      resulting candidate goes through the **identical** promotion gate
+- [ ] `POST /internal/optuna-search` — `X-Internal-Key` guarded, enqueues the task
+- [ ] `optuna` is already in the `ml` extra (`pyproject.toml`) — no new dep
+
+`optuna_search` is just "train with a fresh search" — it shares the registry,
+gate, and artifact path with `train_pricing_model`. No second promotion path.
+
+---
+
+### 6.5 — Pricing-accuracy chart + model-health view
+
+**Backend — `apps/api/routers/listings.py`** (where `/reprice-history` lives):
+- [ ] `GET /listings/pricing-accuracy` — for the authenticated seller, return
+      monthly buckets of `recommended_price` vs realized `sale_price`:
+      `[{month, n, mae, mape, within_20_pct}]` (join `price_predictions ⋈ sales`)
+
+**Backend — ops visibility:**
+- [ ] `GET /internal/models` — `X-Internal-Key` guarded; lists `model_versions`
+      with status + metrics for deploy/debug inspection
+
+**Frontend — `apps/web/app/settings/page.tsx`:**
+- [ ] "Pricing accuracy" widget alongside the existing reprice-history list — a
+      simple MAE-over-time line. Confirm the charting approach against the
+      current web stack first (a minimal inline SVG sparkline keeps the
+      dependency footprint at zero; only add a chart lib if one is already used)
+- [ ] Empty state for sellers with too few sold items to plot
+
+---
+
+### 6.6 — MAE-regression alerting
+
+- [ ] At the **start** of the nightly `train_pricing_model` job, before training:
+      evaluate the **active** model on recent labelled rows (rolling window). If
+      `rolling_mae > active.train_metrics.mae × 1.10`, fire a developer alert
+      (v2 § 8 "Model MAE regression > 10 % post-promotion")
+- [ ] Use the existing notification path — `packages/notifications.notify_seller`
+      to a developer SNS topic (v2 names ntfy.sh; SNS is what is wired today —
+      use SNS, note the discrepancy)
+
+---
+
+## 4. New table DDL
+
+### `model_versions` (global — no `seller_id`, no RLS)
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | |
+| `version` | text | e.g. `v3`, `v4-20260601-0200` |
+| `algorithm` | text | default `lightgbm` |
+| `artifact_s3_key` | text | prefix of the S3 bundle |
+| `feature_cols` | JSONB | exact training feature order |
+| `train_metrics` | JSONB | `{mae, rmse, r2, within_20_pct}` on the backtest slice |
+| `shadow_metrics` | JSONB nullable | rolling post-promotion metrics |
+| `training_row_count` | int | |
+| `status` | enum `model_status` | `training`/`shadow`/`active`/`archived`/`failed` |
+| `trained_at` | timestamptz | |
+| `promoted_at` | timestamptz nullable | |
+| `archived_at` | timestamptz nullable | |
+| `notes` | text nullable | e.g. "optuna search, 40 trials" |
+| `created_at` | timestamptz | `server_default=now()` |
+
+- Partial unique index: `WHERE status = 'active'` → at most one active model.
+
+### `price_predictions` (has `seller_id` → RLS)
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | |
+| `seller_id` | UUID FK → sellers | RLS key |
+| `item_id` | UUID FK → items | |
+| `listing_id` | UUID FK → listings nullable | set on publish |
+| `model_version_id` | UUID FK → model_versions | which model produced this |
+| `features` | JSONB | the 78-key point-in-time feature dict |
+| `features_partial` | bool default false | true for best-effort backfill rows |
+| `model_prediction` | numeric(12,2) | raw model output (post-`expm1`) |
+| `comparable_median` | numeric(12,2) nullable | |
+| `recommended_price` | numeric(12,2) | blended final |
+| `min_acceptable_price` | numeric(12,2) | |
+| `confidence_score` | numeric(5,4) | |
+| `is_shadow` | bool default false | true = produced by a non-active model |
+| `realized_sale_price` | numeric(12,2) nullable | backfilled by the dataset builder |
+| `realized_at` | timestamptz nullable | |
+| `created_at` | timestamptz | `server_default=now()` |
+
+- Indexes: `(model_version_id, is_shadow)`, `(item_id)`, `(seller_id)`.
+
+### `comparable_listings` (has `seller_id` → RLS)
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | UUID PK | |
+| `price_prediction_id` | UUID FK → price_predictions | |
+| `seller_id` | UUID FK → sellers | RLS key |
+| `external_item_id` | text | eBay item ID |
+| `title` | text | |
+| `price` | numeric(12,2) | |
+| `currency` | text | |
+| `condition` | text | |
+| `listing_url` | text | |
+| `relevance` | text | `validated` etc. |
+| `captured_at` | timestamptz | `server_default=now()` |
+
+- Index: `(price_prediction_id)`.
+- *Optional, deferrable:* a pgvector embedding column + HNSW index for
+  comparable-similarity/dedup (v2 § Phase 2 deferred the HNSW index "until
+  Phase 6"). Not required for the retraining loop — list as a stretch item.
+
+---
+
+## 5. New / changed files
+
+| Path | Change |
+|------|--------|
+| `alembic/versions/0013_phase6_ml_tables.py` | new — 3 tables + seed + RLS |
+| `packages/db/models.py` | + `ModelVersion`, `PricePrediction`, `ComparableListing`, `ModelStatus` enum |
+| `packages/agents/pricing/agent.py` | `_model_predict` returns features; `run()` persists predictions; registry-driven artifact load + lazy hot-reload |
+| `packages/ml/dataset.py` | new — `build_training_dataframe`, offer-ratio feature |
+| `packages/ml/train.py` | new — booster training + time-split backtest |
+| `packages/ml/registry.py` | new — version registry, S3 artifact I/O, promote |
+| `packages/ml/evaluate.py` | new — metrics helpers, regression check (or fold into `train.py`) |
+| `workers/sqs_worker.py` | + `train_pricing_model`, `optuna_search` handlers |
+| `apps/api/routers/internal.py` | + `/train-model`, `/optuna-search`, `/models` |
+| `apps/api/routers/listings.py` | + `/listings/pricing-accuracy` |
+| `apps/web/app/settings/page.tsx` | + pricing-accuracy widget |
+| `packages/config.py` | + Phase 6 settings (§ 6) |
+| `scripts/backfill_price_predictions.py` | new — one-time historical seed |
+| `tests/test_phase6_*.py`, `tests/evals/test_eval_pricing.py` | new + updated |
+
+---
+
+## 6. New config keys (`packages/config.py`)
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `ml_artifact_bucket` | `""` | **private** S3 bucket for model bundles (separate from the public images bucket) |
+| `ml_artifact_prefix` | `ml-models` | key prefix within that bucket |
+| `ml_min_training_rows` | `200` | refuse to retrain below this many labelled rows |
+| `ml_promotion_mae_improvement` | `0.02` | required fractional MAE improvement to promote |
+| `ml_promotion_min_r2` | `0.65` | required test-slice R² to promote |
+| `ml_model_reload_check_seconds` | `60` | hot-reload version-check TTL |
+| `optuna_n_trials` | `40` | trials per weekly search |
+
+---
+
+## 7. EventBridge / Scheduler wiring
+
+Both schedules already appear in v2 § 2; this is the wiring checklist:
+
+- [ ] Scheduler target `cron(0 2 * * ? *)` → `POST /internal/train-model`
+      (static `X-Internal-Key` header)
+- [ ] Scheduler target `cron(0 3 ? * SUN *)` → `POST /internal/optuna-search`
+- [ ] EventBridge rule on `model.promoted` (source `salesrep`) — for now just an
+      observability sink / alert; no functional consumer (hot-reload is lazy)
+
+---
+
+## 8. Deployment & ops notes
+
+- **Worker image needs `ml` + `nlp` extras.** The training job re-encodes titles
+  with `sentence-transformers` (the `nlp` extra) **and** trains LightGBM (the
+  `ml` extra). CLAUDE.md notes the `api` image installs `.[nlp]`; verify the
+  SQS-worker image installs `.[ml,nlp]` and add it if not. This is the one place
+  the "NLP extras separate from ML extras" rule is intentionally crossed — the
+  pricing model legitimately depends on both.
+- **IAM:** the EC2 instance role needs `s3:GetObject`/`s3:PutObject` on the ML
+  artifact bucket and `events:PutEvents` (already needed for `emit`).
+- **Compute:** training a LightGBM on a few thousand rows and a 40-trial Optuna
+  search both complete in minutes on the current t3.medium — fine for now. When
+  the dataset grows large, move the job to a one-off ECS task (lands naturally
+  with the Phase 7 Fargate worker).
+- **Migration on deploy:** `0013` follows the existing
+  `alembic upgrade head` deploy step; it is additive (new tables only) so it is
+  safe and non-blocking.
+- **No-AWS local dev:** with `ml_artifact_bucket` empty, the registry falls back
+  to local-file artifacts in `packages/ml/` — exactly today's behaviour — so
+  local dev and CI keep working without S3.
+
+---
+
+## 9. Testing
+
+- [ ] **6.0** Agent 2 writes one `price_predictions` + N `comparable_listings`
+- [ ] **6.1** dataset builder columns, leakage-guard drops, offer-ratio feature
+- [ ] **6.2** promotion gate (all branches), chronological split, registry
+      single-active invariant, full job on seeded data
+- [ ] **6.3** promotion triggers a hot-swap; TTL throttles the version check
+- [ ] **6.4** Optuna task produces a candidate through the same gate
+- [ ] **6.5** `/listings/pricing-accuracy` aggregation; empty state
+- [ ] **6.6** regression check fires the alert above the 10 % threshold
+- [ ] Existing `tests/evals/test_eval_pricing.py` still green; consider adding a
+      backtest-MAE eval to the CodeBuild `tests/evals/` run
+
+---
+
+## 10. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Too few sold-with-prediction rows for a long time | 6.0a backfill; `ml_min_training_rows` floor; v3 stays active until genuinely beaten |
+| Random split leaks future market conditions | Strictly chronological 80/20 split |
+| Recomputed comparables leak post-prediction info | Train only on the stored point-in-time `features` snapshot — never recompute |
+| Bad model promoted | Two-condition gate (MAE win **and** R²); rejected candidates archived with metrics for audit |
+| Hot-reload swap races a concurrent `run()` | Atomic global swap; TTL-throttled check; fallback to comparable-only pricing if a download fails |
+| v3 `.pkl` artifacts only exist on the host by hand | 6.2 bootstrap makes S3 the source of truth — also resolves an existing prod fragility |
+| Worker image missing `ml`/`nlp` extras → job crashes | Explicit deployment checklist item in § 8 |
+
+---
+
+## 11. Suggested sequencing (solo)
+
+| Step | Sub-phase | Notes |
+|------|-----------|-------|
+| 1 | **6.0** schema + capture | Critical path — ship alone, immediately |
+| 2 | 6.0a backfill | Quick win once 6.0 lands |
+| 3 | 6.1 dataset builder | |
+| 4 | 6.2 train job + registry + S3 bootstrap | Largest single piece |
+| 5 | 6.3 hot-reload | Small once the registry exists |
+| 6 | 6.4 Optuna search | Reuses 6.2 wholesale |
+| 7 | 6.5 accuracy chart + 6.6 alerting | Frontend + ops polish |
+| 8 | EventBridge wiring + full test pass | |
+
+Rough estimate: **~1.5–2 weeks solo**, but the *useful output* of the loop is
+gated on real sale volume accumulating after step 1 — build 6.0 first so that
+clock starts as early as possible.
+
+---
+
+*End of Phase 6 implementation plan.*

--- a/phase_7_implementation_plan.md
+++ b/phase_7_implementation_plan.md
@@ -1,0 +1,359 @@
+# Phase 7 — Polish + Launch — Implementation Plan
+
+> Companion to **`implementation_plan_v2.md`** § Phase 7. Read that first.
+> **Goal:** take the working agent system from "functional" to "a product real
+> sellers can sign up for, pay for, and trust" — UI polish, a guided onboarding
+> flow, Stripe billing, a public demo, docs, and the ECS Fargate worker move.
+>
+> **Why Phase 7 before Phase 6:** the Phase 6 retraining loop produces nothing
+> until real sellers are on the platform and items actually sell. Phase 7 is what
+> brings sellers in — it is the prerequisite for Phase 6 to be worth building.
+>
+> **Status when this plan was written (2026-05-15):** Phases 0–5 complete.
+> One Phase 7 item is already done — lint + pytest phases are in `buildspec.yml`.
+> Remaining: UI polish, onboarding, Stripe, ECS Fargate, README, demo mode.
+
+---
+
+## 1. Current state & scope notes
+
+Findings from the codebase that shape this plan:
+
+- **The web app has no component library.** `apps/web/` is Next.js 15 (app
+  router) + React 19 + Tailwind 3.4, ~1,500 lines of hand-rolled JSX across 5
+  pages (`/login`, `/chat`, `/inbox`, `/settings`, `/` redirect). No
+  `components/` directory, no shadcn/ui, no design primitives. The UI polish
+  task is therefore a **refactor + restyle**, not a fresh paint job.
+- **`Seller` has no billing or onboarding columns.** Adding Stripe and a
+  guided onboarding flow both need a schema migration.
+- **The SQS worker runs on EC2** via `docker compose --profile worker`, sharing
+  the heavy API image (pre-baked HuggingFace + spaCy models). Moving it to
+  Fargate forces a CI/CD change — see § 1.1.
+- **No registry in the build pipeline.** CodeBuild does `git pull && docker
+  compose build` directly on the EC2 host. Nothing is pushed to ECR today.
+
+### 1.1 ECS Fargate is the highest-effort, lowest-user-value item — sequence it last
+
+The v2 Phase 7 list includes the Fargate worker move. Be aware it is not a
+contained task: Fargate cannot pull a locally-built image, so 7.4 **requires**
+the CodeBuild pipeline to start building and pushing the image to **ECR**, plus
+new VPC/subnet wiring, an IAM task role, target-tracking autoscaling, and a
+CloudWatch alarm. It delivers zero user-visible improvement — the EC2
+`--profile worker` setup works fine at low volume.
+
+**Recommendation:** do 7.4 **last** within Phase 7, and only if the single EC2
+host is a genuine reliability/throughput problem. If it is not, defer it to
+post-launch. The plan keeps it as § 7.4 but flags it as deferrable.
+
+### 1.2 Slip Phase 6.0 in early — in parallel with Phase 7
+
+Phase 6's value is gated on training data accumulating from real users. **Ship
+Phase 6.0 (the schema + prediction-logging in Agent 2 — see
+`phase_6_implementation_plan.md` § 6.0) before or alongside Phase 7**, so the
+first cohort of paying sellers' pricing decisions are captured instead of
+discarded. It is ~1 day of work and has no UI surface. The rest of Phase 6 still
+waits for volume. This plan does not re-specify 6.0 — treat it as a parallel track.
+
+---
+
+## 2. Sub-phase breakdown
+
+Sequenced so the shared component layer (7.1) lands first — onboarding, billing,
+and demo mode all render on top of it.
+
+| Order | Sub-phase | Effort (solo) | User-visible |
+|-------|-----------|---------------|--------------|
+| 1 | 7.1 UI polish — shadcn/ui + responsive | ~1 week | High |
+| 2 | 7.2 Onboarding flow | ~3 days | High |
+| 3 | 7.6 Public demo mode | ~2–3 days | High (acquisition) |
+| 4 | 7.3 Stripe billing | ~4–5 days | High (revenue) |
+| 5 | 7.5 README + architecture write-up | ~1 day | Low |
+| 6 | 7.4 ECS Fargate worker | ~3–5 days | None — *deferrable* |
+
+7.3 is backend-heavy and can run in parallel with 7.2/7.6 if desired.
+
+---
+
+### 7.1 — UI polish (shadcn/ui + mobile-responsive)
+
+**Establish a component layer:**
+- [ ] Install shadcn/ui (Radix UI + `class-variance-authority` + `tailwind-merge`
+      + `clsx`; `components.json` config). Confirmed compatible with Next 15 +
+      React 19 + Tailwind 3.4
+- [ ] Add `apps/web/components/ui/` with the core primitives actually used:
+      `button`, `input`, `card`, `badge`, `dialog`, `tabs`, `toast`/`sonner`,
+      `skeleton`, `select`
+- [ ] Define a small theme in `tailwind.config.ts` + `globals.css` (CSS
+      variables for colour, radius) — one consistent visual language
+
+**Refactor pages onto the layer — incrementally, one page per PR:**
+- [ ] `/login` (+ signup) — forms onto `input`/`button`, inline validation
+- [ ] `/chat` (624 lines — the largest) — extract the chat sidebar, message
+      bubbles, pricing panel, image upload into components
+- [ ] `/inbox` — draft cards, approve/edit/dismiss actions onto `card`/`dialog`
+- [ ] `/settings` — autonomy radios, reprice history onto `card`/`select`
+- [ ] Shared app shell: a single nav/sidebar component (the Settings link is
+      currently duplicated across `/chat` and `/inbox`)
+
+**Mobile-responsive:**
+- [ ] Tailwind breakpoints on every page; the desktop-sidebar layouts collapse
+      to a drawer/stacked layout on small screens
+- [ ] Loading states via `skeleton`; replace blank waits on the poll-driven
+      pricing/draft views
+- [ ] Manual test golden paths in a mobile viewport before sign-off
+
+**Note:** big-bang rewrites of working pages are risky — go page-by-page, keep
+each page shippable. This is pure frontend; nothing is gated behind a flag.
+
+---
+
+### 7.2 — Onboarding flow
+
+New sellers currently land straight on `/chat` with no eBay connection and no
+guidance. Add a guided first-run path.
+
+**Schema (migration — see § 4):**
+- [ ] `sellers.onboarding_completed` bool default false — lets the walkthrough
+      be dismissed and not re-shown
+
+**Flow — `/onboarding` route, a 3-step stepper:**
+- [ ] Step 1 — **Connect eBay**: triggers the existing eBay OAuth flow
+      (`apps/api/routers/ebay.py`); "connected" is derived from a
+      `platform_credentials` row
+- [ ] Step 2 — **Notifications + autonomy**: opt into SNS notifications, pick an
+      autonomy level (reuses the existing `/settings` PATCH endpoints; default
+      stays `draft`)
+- [ ] Step 3 — **List your first item**: hand off into `/chat` with a short
+      coach-mark overlay on the first intake
+
+**Routing:**
+- [ ] After login, redirect to `/onboarding` while `onboarding_completed` is
+      false and no `platform_credentials` row exists; otherwise `/chat`
+- [ ] "Skip for now" sets `onboarding_completed = true`
+- [ ] `GET /settings/seller` (or `/auth/me`) returns `onboarding_completed` so
+      the frontend can route without guessing
+
+**Tests:**
+- [ ] New seller is routed to `/onboarding`; completing/skipping routes to `/chat`
+
+---
+
+### 7.3 — Stripe subscription billing (Free + Pro)
+
+**Schema (migration — see § 4) — new `Seller` columns:**
+- [ ] `stripe_customer_id` text nullable
+- [ ] `plan` enum `plan_tier` (`free` | `pro`) default `free`
+- [ ] `subscription_status` enum (`none` | `trialing` | `active` | `past_due`
+      | `canceled`) default `none`
+- [ ] `stripe_subscription_id` text nullable
+- [ ] `current_period_end` timestamptz nullable
+
+**Stripe setup (dashboard / one-time):**
+- [ ] Create the Pro product + recurring price; record the price ID
+- [ ] Note the webhook signing secret for the events below
+
+**Backend — new router `apps/api/routers/billing.py`:**
+- [ ] `POST /billing/checkout-session` — creates a Stripe Checkout session for
+      the authenticated seller, returns the redirect URL (success/cancel URLs
+      built from `frontend_base_url`)
+- [ ] `POST /billing/portal-session` — creates a Stripe Customer Portal session
+      so sellers manage/cancel their own subscription
+- [ ] `GET /billing/status` — current plan + `subscription_status` +
+      `current_period_end` for the UI
+- [ ] `POST /billing/webhook` — Stripe events, **`Stripe-Signature` verified via
+      `stripe.Webhook.construct_event`** (same defence pattern as the eBay
+      webhooks). Handle: `checkout.session.completed`,
+      `customer.subscription.updated`, `customer.subscription.deleted`,
+      `invoice.payment_failed` — each updates the `Seller` billing columns
+- [ ] Register the router in `apps/api/main.py`
+- [ ] Add `stripe` to `pyproject.toml` dependencies
+
+**Plan enforcement** — *needs a product decision before coding*:
+- [ ] Decide what Free vs Pro actually gates. Candidates: a monthly listing cap,
+      access to `full_auto` autonomy, access to automatic stale-reprice. Recommend
+      keeping the gate **small and reversible** for launch
+- [ ] A `require_pro` FastAPI dependency (or a usage check) on the gated routes;
+      gracefully returns a 402/403 the UI turns into an upgrade prompt
+
+**Frontend:**
+- [ ] Billing section in `/settings` (or a `/billing` page): current plan,
+      "Upgrade to Pro" → Checkout redirect, "Manage subscription" → Portal redirect
+- [ ] Upgrade prompts where a gated feature is hit
+
+**Config (`packages/config.py`):** `stripe_secret_key`, `stripe_publishable_key`,
+`stripe_webhook_secret`, `stripe_price_id_pro`, `billing_enabled` (default
+`false` so local/CI run without Stripe).
+
+**Tests:**
+- [ ] Webhook handler updates `Seller` correctly per event type; bad signature
+      rejected
+- [ ] `require_pro` dependency allows Pro, blocks Free
+- [ ] Checkout/portal session creation with the Stripe SDK mocked
+
+---
+
+### 7.4 — ECS Fargate worker  *(lowest priority — defer if EC2 is fine)*
+
+See § 1.1 — this is the biggest hidden-cost item and delivers no user-visible
+value. Build it last, or defer past launch.
+
+**CI/CD change (the real cost):**
+- [ ] CodeBuild builds the image and **pushes to ECR** (new repository), tagged
+      by commit SHA — the worker can no longer use a host-local image
+- [ ] Keep the existing SSM → EC2 deploy for the API (or migrate the API to
+      ECR too — out of scope here)
+
+**ECS:**
+- [ ] Fargate task definition: same image, entrypoint
+      `uv run python -m workers.sqs_worker`; sized for the pre-baked HF/spaCy
+      models (note the large image → slower cold start)
+- [ ] ECS service in the existing VPC/subnets; IAM **task role** with SQS, S3,
+      and RDS access; logs via the `awslogs` driver (a bonus — there is no
+      CloudWatch agent on the EC2 host today)
+- [ ] Application Auto Scaling — target tracking on the SQS
+      `ApproximateNumberOfMessagesVisible` metric, ~1 task per 10 messages
+      (v2 § 10), min 0–1 / sensible max
+- [ ] Remove the `--profile worker` service from the EC2 deploy once the
+      Fargate service is verified
+
+**Tests / verification:**
+- [ ] Enqueue a test task; confirm a Fargate task picks it up and scales down
+
+---
+
+### 7.5 — README + architecture write-up
+
+- [ ] Rewrite `README.md` (currently minimal) as a public-facing doc: what it
+      does, quickstart (`make up`), the `.env` it needs
+- [ ] Architecture section — distil the v2 plan's diagrams; a clear
+      4-agents + NLP-pipeline overview, the eBay-only-server-side constraint,
+      the SQS/EventBridge topology
+- [ ] Screenshots once 7.1 lands (chat, inbox, settings)
+- [ ] Keep `CLAUDE.md` / `AGENTS.md` as the contributor docs; README is the
+      front door
+
+---
+
+### 7.6 — Public demo mode (read-only seeded account)
+
+**Schema (migration — see § 4):**
+- [ ] `sellers.is_demo` bool default false
+
+**Seed:**
+- [ ] `scripts/seed_demo.py` — creates one demo seller pre-populated with items,
+      published listings, buyer conversations, drafts, and a couple of sales, so
+      every screen has realistic content
+- [ ] Idempotent (safe to re-run)
+
+**Read-only guard:**
+- [ ] A FastAPI dependency that rejects all mutating requests
+      (POST/PATCH/DELETE) for a demo seller with a friendly 403 — so the demo
+      cannot be vandalised
+- [ ] Exclude demo sellers from inbound eBay webhook processing (no real eBay
+      account is attached)
+
+**Access:**
+- [ ] "Try the live demo" button on `/login` — issues a JWT for the demo seller
+      and drops the visitor straight into `/chat`
+- [ ] Demo state stays stable because writes are blocked — no periodic reset
+      needed; re-running the seed is the reset if ever required
+
+**Tests:**
+- [ ] Demo seller: reads succeed, writes return 403
+
+---
+
+## 3. New routers / files summary
+
+| Path | Change |
+|------|--------|
+| `alembic/versions/00XX_phase7_billing_onboarding.py` | new — `Seller` billing/onboarding/demo columns + 2 enums |
+| `packages/db/models.py` | + `Seller` columns; `PlanTier`, `SubscriptionStatus` enums |
+| `apps/api/routers/billing.py` | new — checkout, portal, status, Stripe webhook |
+| `apps/api/main.py` | register `billing.router` |
+| `apps/api/dependencies` (or where deps live) | `require_pro`, `block_demo_writes` |
+| `packages/config.py` | + Stripe + `billing_enabled` settings (§ 7.3) |
+| `scripts/seed_demo.py` | new — demo account seed |
+| `apps/web/components/ui/*` | new — shadcn primitives |
+| `apps/web/components/*` | new — app shell, chat/inbox/pricing components |
+| `apps/web/app/onboarding/page.tsx` | new — 3-step stepper |
+| `apps/web/app/{login,chat,inbox,settings}/page.tsx` | refactored onto components |
+| `apps/web/app/settings/page.tsx` | + billing section |
+| `buildspec.yml` | 7.4 only — build + push to ECR |
+| `infrastructure/ecs-fargate-worker.md` | 7.4 only — Fargate runbook (matches `s3-images-setup.md`) |
+| `README.md` | rewritten |
+
+**Migration numbering:** Phase 6's plan also reserves `0013`. Whichever ships
+first takes `0013`; the other becomes `0014`. Use a descriptive slug regardless.
+
+---
+
+## 4. Schema migration (Phase 7)
+
+One migration, all additive — new nullable columns / columns with defaults on
+`sellers`, plus two new enum types. Safe and non-blocking on deploy.
+
+| Column | Type | Default | Sub-phase |
+|--------|------|---------|-----------|
+| `onboarding_completed` | bool | `false` | 7.2 |
+| `is_demo` | bool | `false` | 7.6 |
+| `stripe_customer_id` | text nullable | — | 7.3 |
+| `plan` | enum `plan_tier` (`free`/`pro`) | `free` | 7.3 |
+| `subscription_status` | enum (`none`/`trialing`/`active`/`past_due`/`canceled`) | `none` | 7.3 |
+| `stripe_subscription_id` | text nullable | — | 7.3 |
+| `current_period_end` | timestamptz nullable | — | 7.3 |
+
+`sellers` already has RLS (`0002_rls_policies.py`); new columns inherit it — no
+policy change needed.
+
+---
+
+## 5. Deployment & ops notes
+
+- **Stripe webhook URL** must be registered in the Stripe dashboard pointing at
+  `https://devopslearn.store/billing/webhook`; the signing secret goes in the
+  prod `.env` as `STRIPE_WEBHOOK_SECRET`.
+- **`billing_enabled=false`** in local/CI keeps everything runnable without
+  Stripe keys — billing routes return a clean disabled response.
+- **Frontend redirects** (Stripe success/cancel, eBay OAuth, onboarding) all key
+  off `frontend_base_url` — confirm it is correct in prod.
+- **Web deploy path:** the app is currently served via
+  `apps/api/routers/pages.py`. Confirm whether 7.1's new build still deploys the
+  same way before sign-off (the larger shadcn bundle should be fine, but verify).
+- **7.4 only:** moving the worker to Fargate adds an ECR repo, a task role, and
+  autoscaling — see § 1.1. Until then the EC2 `--profile worker` stays.
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| shadcn refactor breaks working pages | One page per PR; manual golden-path test each; pages stay shippable |
+| Stripe webhook spoofing | `Stripe-Signature` verified via `construct_event` — same rigour as the eBay webhooks |
+| Stripe/DB drift (webhook missed) | Webhook is the source of truth; reconcile on `GET /billing/status` by re-reading Stripe if stale |
+| Free/Pro gate undecided → blocks 7.3 | Settle the gate as a product decision *before* coding; keep it small and reversible |
+| Demo account abused / mutated | Hard write-block dependency; demo sellers excluded from webhooks |
+| 7.4 scope creep (ECR + VPC + IAM + autoscale) | Sequenced last and explicitly deferrable; EC2 worker is a fine fallback |
+| Phase 7 ships, but no pricing data captured | Ship Phase 6.0 in parallel (§ 1.2) so launch-cohort data is not lost |
+
+---
+
+## 7. Suggested sequencing (solo)
+
+| Step | Sub-phase | Notes |
+|------|-----------|-------|
+| 0 | Phase **6.0** (parallel track) | Prediction logging — ship early, ~1 day |
+| 1 | 7.1 UI polish | Component layer first — everything else builds on it |
+| 2 | 7.2 Onboarding | Needs the component layer |
+| 3 | 7.6 Demo mode | Pairs with onboarding (the `/login` "try demo" button) |
+| 4 | 7.3 Stripe billing | Backend-heavy; can overlap 7.2/7.6 |
+| 5 | 7.5 README | Cheap; do once screenshots exist |
+| 6 | 7.4 ECS Fargate | Last — or defer past launch (§ 1.1) |
+
+Rough estimate: **~2.5–3.5 weeks solo**, the wide range driven by whether 7.4 is
+done now or deferred. Excluding 7.4: **~2–2.5 weeks**.
+
+---
+
+*End of Phase 7 implementation plan.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "boto3>=1.35",
   "typing-extensions>=4.12",
   "langchain-openai>=1.2.1",
+  "stripe>=10.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -3267,6 +3267,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "stripe" },
     { name = "structlog" },
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
@@ -3346,6 +3347,7 @@ requires-dist = [
     { name = "sentence-transformers", marker = "extra == 'nlp'", specifier = ">=3.3" },
     { name = "spacy", marker = "extra == 'nlp'", specifier = ">=3.8" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "stripe", specifier = ">=10.0" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "torch", marker = "sys_platform == 'linux' and extra == 'nlp'", specifier = ">=2.2", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "sys_platform != 'linux' and extra == 'nlp'", specifier = ">=2.2" },
@@ -3771,6 +3773,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "stripe"
+version = "15.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/26/5d6f5f5beae6f1ff78213e2e6f4fbd431518dcd98733cdd39fb4ba0d01d3/stripe-15.1.0.tar.gz", hash = "sha256:24bd3b6bd0969a4841bd4d7681556a9e35e46c414a07c8590a225fbd5a878450", size = 1501673, upload-time = "2026-04-24T00:18:58.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/4e/fd9cb74ddf1e61fb6241e2f6799a81ef99bf6cf2e94f8812ee1cd5458e5d/stripe-15.1.0-py3-none-any.whl", hash = "sha256:bdfb556be08662a41833e6403607ebf12e0062cae4f9b93e2b89b6ba926d7c82", size = 2143199, upload-time = "2026-04-24T00:18:56.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
 
This PR ships Phase 6.0 (ML retraining data capture) and Phase 7 (Stripe billing, onboarding flow, demo mode, and a full UI rebuild) together.

### Phase 6.0 — ML retraining data capture
- **Migration 0013**: `model_versions`, `price_predictions`, `comparable_listings` tables + RLS
- **packages/ml/registry.py**: active model version with 60s cache
- **Agent 2**: persists 78-feature snapshot + comparables after every pricing run

### Phase 7 — Backend
- **Migration 0014**: `onboarding_completed`, `is_demo`, `stripe_*`, `plan`, `subscription_status` on sellers
- **GET /auth/demo**: shared read-only demo account (creates on first call)
- **GET /settings/seller/onboarding-status** + **POST /settings/seller/complete-onboarding**
- **apps/api/routers/billing.py**: Stripe checkout, portal, status, webhook (gated by `BILLING_ENABLED`)
- **apps/api/deps.py**: `require_not_demo` dependency returns 403 for demo sellers on writes
- **stripe>=10.0** added to `pyproject.toml`
 
### Phase 7 — Frontend
- **Tailwind CSS variable theming**: (`--primary`, `--background`, `--muted`, `--card`, etc.)
- **Component layer**: Button, Input, Card, Badge, Skeleton, Textarea, Label (shadcn-style, CVA)
- **AppShell**: desktop sidebar + mobile slide-in drawer, inbox badge, eBay status, logout
- **Toast component**: success/error/info with 5s auto-dismiss
- **/login**: routed to `/onboarding` on first login; "Try the live demo" button
- **/onboarding**: 3-step stepper (connect eBay → reply mode → confirm)
- **/chat**: AppShell, pricing sidebar, image upload, mobile-responsive
- **/inbox**: inline draft edit with Approve/Save&Send/Dismiss
- **/settings**: BillingCard (upgrade → Stripe Checkout, manage → Stripe Portal), autonomy, reprice, stats
- **lib/api.ts**: `BillingStatus` type + 6 new API methods

README fully rewritten.

## Notes
- `BILLING_ENABLED` defaults to false — no impact on existing deploys
- `scripts/seed_demo.py` is gitignored but exists locally; run after `/auth/demo` to populate fixtures
- `npm install` needed after pull to pick up `lucide-react`, `clsx`, `class-variance-authority`, `tailwind-merge`
 
## Test plan
- [ ] `make ci` passes
- [ ] `make migrate` applies 0013 + 0014 cleanly
- [ ] `npm --prefix apps/web install && npm run build` succeeds (TypeScript clean)
- [ ] `GET /auth/demo` creates demo seller; second call returns same seller
- [ ] Login routes to `/onboarding` for new seller, `/chat` for existing
- [ ] Demo account: mutating endpoints return 403
- [ ] `BILLING_ENABLED=false`: `/billing/*` returns 503
- [ ] With Stripe test keys: checkout and portal return redirect URLs
- [ ] `/settings` BillingCard, `/inbox` draft actions, `/onboarding` stepper all work
- [ ] Mobile: hamburger opens sidebar drawer