### PR TITLE
feat: implement dynamic price blending with comparable weight taperin…

### DIFF
--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -8,7 +8,9 @@ Determines optimal pricing for items by combining two signals:
   2. Live eBay comparable median — current market prices from the Browse API.
 
 The model prediction already incorporates comparable stats as features (dominant
-signal), so the model gets the majority weight in the final blend (60 / 40).
+signal), so the model gets the majority weight in the final blend (60 / 40). When
+fewer than _MIN_CONFIDENT_COMPARABLES comparables are found the median's 40% share
+tapers toward 0 and shifts to the model.
 
 Comparable collection uses a multi-round adaptive strategy:
   - Round 0: Initial search with category filter + brand-first query.
@@ -134,6 +136,10 @@ def _get_sentence_model():
 _DEFAULT_FLOOR_RATIO = 0.70  # Default minimum price is 70% of recommended
 _MODEL_WEIGHT = 0.60  # ML Model contributes 60% to final price
 _TARGET_COMPARABLES = 20  # Try to find 20 matching items on eBay
+# Below this many comparables the median is treated as small-sample noise: its
+# weight in the final blend tapers linearly toward 0 and the freed weight shifts
+# to the model. At or above it, the standard _MODEL_WEIGHT split holds.
+_MIN_CONFIDENT_COMPARABLES = 6
 _MAX_SEARCH_ROUNDS = 3  # Rounds 0-1 use condition filter; round 2 drops it as fallback
 
 # ---------------------------------------------------------------------------
@@ -467,6 +473,32 @@ async def _persist_prediction(
         logger.exception("[pricing] Failed to persist prediction — continuing without logging")
 
 
+def _blend_price(
+    comparable_median: float | None,
+    model_pred: float | None,
+    n_comparables: int,
+) -> float:
+    """Combine the live comparable median and the model prediction.
+
+    With at least _MIN_CONFIDENT_COMPARABLES comparables the median is a solid
+    market signal and keeps its full ``1 - _MODEL_WEIGHT`` share. Below that
+    threshold the median is small-sample noise, so its weight tapers linearly
+    toward 0 in proportion to how few comparables were found and the freed
+    weight shifts to the model. At exactly the threshold this is identical to
+    the standard blend. When only one signal is available it is used on its own.
+    """
+    if comparable_median is not None and model_pred is not None:
+        comparable_weight = 1 - _MODEL_WEIGHT
+        if n_comparables < _MIN_CONFIDENT_COMPARABLES:
+            comparable_weight *= n_comparables / _MIN_CONFIDENT_COMPARABLES
+        return comparable_weight * comparable_median + (1 - comparable_weight) * model_pred
+    if comparable_median is not None:
+        return comparable_median
+    if model_pred is not None:
+        return model_pred
+    return 0.0
+
+
 @traceable(name="pricing_agent", run_type="chain")
 async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -> PricingResult:
     """Agent 2 — Pricing (v3 model).
@@ -500,15 +532,9 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
     # Get price prediction from historical ML model
     model_pred, model_features = _model_predict(row, prices)
 
-    # Weighted average of model prediction and comparable median
-    if comparable_median is not None and model_pred is not None:
-        recommended = (1 - _MODEL_WEIGHT) * comparable_median + _MODEL_WEIGHT * model_pred
-    elif comparable_median is not None:
-        recommended = comparable_median
-    elif model_pred is not None:
-        recommended = model_pred
-    else:
-        recommended = 0.0
+    # Blend the model prediction with the live comparable median, tapering the
+    # median's weight when too few comparables were found to trust it.
+    recommended = _blend_price(comparable_median, model_pred, len(prices))
 
     if len(prices) >= 2:
         price_low = float(np.percentile(prices, 25))

--- a/tests/test_pricing_agent.py
+++ b/tests/test_pricing_agent.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from packages.agents.pricing import agent
+from packages.agents.pricing.agent import _blend_price
 
 
 def test_get_sentence_model_missing_dependency_raises():
@@ -16,3 +17,42 @@ def test_get_sentence_model_missing_dependency_raises():
         pytest.raises(RuntimeError, match="sentence-transformers is required for pricing v3"),
     ):
         agent._get_sentence_model()
+
+
+# ---------------------------------------------------------------------------
+# _blend_price — confidence-weighted blend of model prediction + comparables
+# ---------------------------------------------------------------------------
+
+# A low comparable median (100) vs a higher model prediction (200) makes the
+# direction of any weight shift easy to read: more model weight ⇒ higher price.
+_LOW_MEDIAN = 100.0
+_HIGH_MODEL = 200.0
+
+
+@pytest.mark.parametrize(
+    "n_comparables",
+    [agent._MIN_CONFIDENT_COMPARABLES, agent._MIN_CONFIDENT_COMPARABLES + 10],
+)
+def test_blend_price_uses_standard_split_when_comparables_are_sufficient(n_comparables):
+    """At or above the threshold the standard _MODEL_WEIGHT split is used."""
+    expected = (1 - agent._MODEL_WEIGHT) * _LOW_MEDIAN + agent._MODEL_WEIGHT * _HIGH_MODEL
+    assert _blend_price(_LOW_MEDIAN, _HIGH_MODEL, n_comparables) == pytest.approx(expected)
+
+
+def test_blend_price_tapers_comparable_weight_when_too_few_comparables():
+    """Below the threshold the median's weight shrinks, shifting trust to the model."""
+    few = agent._MIN_CONFIDENT_COMPARABLES - 1
+    comparable_weight = (1 - agent._MODEL_WEIGHT) * (few / agent._MIN_CONFIDENT_COMPARABLES)
+    expected = comparable_weight * _LOW_MEDIAN + (1 - comparable_weight) * _HIGH_MODEL
+
+    result = _blend_price(_LOW_MEDIAN, _HIGH_MODEL, few)
+
+    assert result == pytest.approx(expected)
+    # Fewer comparables ⇒ result sits closer to the (higher) model prediction.
+    assert result > _blend_price(_LOW_MEDIAN, _HIGH_MODEL, agent._MIN_CONFIDENT_COMPARABLES)
+
+
+def test_blend_price_falls_back_to_a_single_available_signal():
+    assert _blend_price(150.0, None, 3) == 150.0  # model unavailable
+    assert _blend_price(None, 250.0, 3) == 250.0  # comparables unavailable
+    assert _blend_price(None, None, 0) == 0.0


### PR DESCRIPTION

⏺ You've spotted a genuine architectural smell. Comparables enter the final price twice:

  1. As a feature into the model — _model_predict(row, prices) takes the comparable prices, so the LightGBM output is already comparable-informed.
  2. As an explicit term in the blend — recommended = 0.6 · model_pred + 0.4 · comparable_median.

  So the effective weight on comparables is 0.4 + 0.6 · (whatever the model learned internally) — an arbitrary hand-set number stacked on top of a learned one. That's not principled, and yes, it does shrink flexibility: when the model
  has correctly learned this item should sell well above or below the comparable median (rare variant, unusually good condition, poor comparable matches), the 0.4 · comparable_median term drags the answer 40% back toward the median and
   dampens a deviation that was right.

  Why it's there anyway (the steelman)

  It's a freshness guardrail. The LightGBM model is trained on historical sales, and the retraining loop is Phase 6 — not built yet. A stale model's price level drifts from today's market (new releases, demand shifts, inflation). The
  live comparable median is fresh. The explicit 0.4 · comparable_median yanks a possibly-stale model back toward current reality. It also caps model errors. So right now, that dampening is partly protective — the problem is it dampens
  correct deviations and model errors equally, with a fixed weight, while double-counting.

  The cleaner design — decouple the two roles

  Don't make comparables do the same job in two places. Give each signal a distinct, non-overlapping role:

  - Model → predicts intrinsic value from item attributes only (specs, brand, age, condition, title/desc embeddings) — no comparable prices as features.
  - Comparables → the live-market anchor.
  - Blend → now fuses two genuinely independent estimates: "what this item is intrinsically worth" × "what the market is doing today." No double-count, and you keep the freshness guardrail.

  That's the change I'd make. Two weaker alternatives:

  - Model-only (drop the explicit blend, let the model learn the comparable weight from data) — correct in principle, but unsafe until Phase 6 retraining exists. Don't do this with a stale model.
  - Confidence-weighted blend — replace the fixed 0.6/0.4 with a weight driven by comparable count/match quality and model confidence (few/poor comparables → trust the model more). Worth doing regardless of the above.

  A side benefit: decoupling makes your residual-CNN idea cleaner too — expected_price becomes the model's intrinsic prediction, and the CNN/comparables layer on market + condition adjustments without circular dependence.

  So: keep blending, but stop feeding comparables into the model — that removes the double-count while preserving the guardrail you actually need until retraining is live.

✻ Sautéed for 1m 21s

❯ do a confidence weighted blend that only gets initiated if when we hit too low of a threshold of number of comparables less than 6 i would say                                                                                           

⏺ Let me read the pricing agent's constants and check for existing pricing tests:

  Searched for 2 patterns, read 2 files, listed 1 directory (ctrl+o to expand)

⏺ All the pieces are in place. Implementing the confidence-weighted blend — I'll extract a pure _blend_price helper so the logic is testable:
