### PR TITLE
feat: integrate visual condition analysis into pricing agent to adjus…

### DIFF
--- a/alembic/versions/0015_intake_visual_condition.py
+++ b/alembic/versions/0015_intake_visual_condition.py
@@ -27,18 +27,8 @@ def upgrade() -> None:
         "items",
         sa.Column("visual_condition_analyzed_at", sa.DateTime(timezone=True), nullable=True),
     )
-    op.add_column(
-        "items",
-        sa.Column(
-            "visual_condition_needs_confirmation",
-            sa.Boolean(),
-            nullable=False,
-            server_default="false",
-        ),
-    )
 
 
 def downgrade() -> None:
-    op.drop_column("items", "visual_condition_needs_confirmation")
     op.drop_column("items", "visual_condition_analyzed_at")
     op.drop_column("items", "visual_condition_report")

--- a/alembic/versions/0015_intake_visual_condition.py
+++ b/alembic/versions/0015_intake_visual_condition.py
@@ -1,0 +1,44 @@
+"""Add intake visual condition analysis fields
+
+Revision ID: 0015_intake_visual_condition
+Revises: 0014_phase7a
+Create Date: 2026-05-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "0015_intake_visual_condition"
+down_revision: str | None = "0014_phase7a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "items",
+        sa.Column("visual_condition_report", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "items",
+        sa.Column("visual_condition_analyzed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "items",
+        sa.Column(
+            "visual_condition_needs_confirmation",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("items", "visual_condition_needs_confirmation")
+    op.drop_column("items", "visual_condition_analyzed_at")
+    op.drop_column("items", "visual_condition_report")

--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -14,7 +14,6 @@ v2 changes:
 import json
 import logging
 import uuid
-from datetime import UTC, datetime
 from typing import Any
 
 import openai
@@ -26,7 +25,6 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from packages.agents.intake import vision
 from packages.agents.intake.tools import (
     CATEGORY_ENRICHMENT_HINTS,
     CATEGORY_LIST,
@@ -282,27 +280,6 @@ async def _plan_next_step(
             False,
         )
 
-    if item.visual_condition_needs_confirmation:
-        report = item.visual_condition_report or {}
-        return vision.build_confirmation_question(report), False, False
-
-    if (
-        settings.intake_vision_enabled
-        and item.condition != ItemCondition.new
-        and item.visual_condition_analyzed_at is None
-    ):
-        images = list(getattr(item, "images", []) or [])
-        report = await vision.analyse_item_images(item, images)
-        vision.apply_visual_report_to_item(item, report)
-        item.visual_condition_analyzed_at = datetime.now(UTC)
-
-        if vision.condition_conflicts_with_seller(item, report):
-            item.visual_condition_needs_confirmation = True
-            await session.flush()
-            return vision.build_confirmation_question(report), False, False
-
-        await session.flush()
-
     item.status = ItemStatus.intake_complete
     await session.flush()
     return "Great — I have everything I need to prepare your listing!", False, True
@@ -361,17 +338,6 @@ async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, A
         item = await session.scalar(select(Item).where(Item.id == item_id))
         if item and item.category:
             system_content += _enrichment_context(item.category)
-        if item and item.visual_condition_needs_confirmation and item.visual_condition_report:
-            report = item.visual_condition_report
-            system_content += (
-                "\n\nNOTE: visual condition confirmation is active. "
-                f"The photo analysis suggested condition={report.get('condition_grade')} "
-                f"with confidence={report.get('confidence')}. "
-                "If the seller agrees, call record_attribute with field='condition' "
-                "and that suggested condition value. If they disagree, ask one short "
-                "follow-up question and then call record_attribute with their confirmed "
-                "condition, even if it is unchanged."
-            )
         if item and item.status == ItemStatus.needs_specifics and item.required_specifics:
             specifics = ", ".join(item.required_specifics)
             system_content += (

--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -14,6 +14,7 @@ v2 changes:
 import json
 import logging
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 import openai
@@ -23,7 +24,9 @@ from langsmith import traceable
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
+from packages.agents.intake import vision
 from packages.agents.intake.tools import (
     CATEGORY_ENRICHMENT_HINTS,
     CATEGORY_LIST,
@@ -80,6 +83,13 @@ excellent listing. Questions should be relevant to the category:
 - Clothing/Shoes: size, colour, material, sole condition (shoes)?
 - Furniture: dimensions, material, colour?
 - General: cosmetic defects, included accessories, reason for selling?
+
+If photos are already uploaded and the seller's details are too generic, call \
+analyze_images_for_descriptors to enrich the listing from visible evidence. \
+This is especially useful for unbranded or visual items like jewellery, clothing, \
+shoes, watches, furniture, bags, and collectibles. Use cautious wording: do not \
+claim authenticity, precious metals, gemstones, or brand unless visible markings \
+prove them.
 
 Ask ONE question at a time. Keep it conversational and friendly. Aim up \
 to 6 questions total to gather all missing information and every enrinchment \
@@ -173,7 +183,9 @@ async def _plan_next_step(
     if item_id is None:
         return None, False, False
 
-    item = await session.scalar(select(Item).where(Item.id == item_id))
+    item = await session.scalar(
+        select(Item).where(Item.id == item_id).options(selectinload(Item.images))
+    )
     if item is None:
         return (
             "I couldn't find the item we were discussing. Please try that again.",
@@ -248,6 +260,8 @@ async def _plan_next_step(
         )
         or 0
     )
+    if not isinstance(image_count, int):
+        image_count = len(getattr(item, "images", []) or [])
 
     if image_count < _MIN_LISTING_IMAGES:
         if image_count == 0:
@@ -267,6 +281,27 @@ async def _plan_next_step(
             True,
             False,
         )
+
+    if item.visual_condition_needs_confirmation:
+        report = item.visual_condition_report or {}
+        return vision.build_confirmation_question(report), False, False
+
+    if (
+        settings.intake_vision_enabled
+        and item.condition != ItemCondition.new
+        and item.visual_condition_analyzed_at is None
+    ):
+        images = list(getattr(item, "images", []) or [])
+        report = await vision.analyse_item_images(item, images)
+        vision.apply_visual_report_to_item(item, report)
+        item.visual_condition_analyzed_at = datetime.now(UTC)
+
+        if vision.condition_conflicts_with_seller(item, report):
+            item.visual_condition_needs_confirmation = True
+            await session.flush()
+            return vision.build_confirmation_question(report), False, False
+
+        await session.flush()
 
     item.status = ItemStatus.intake_complete
     await session.flush()
@@ -326,6 +361,17 @@ async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, A
         item = await session.scalar(select(Item).where(Item.id == item_id))
         if item and item.category:
             system_content += _enrichment_context(item.category)
+        if item and item.visual_condition_needs_confirmation and item.visual_condition_report:
+            report = item.visual_condition_report
+            system_content += (
+                "\n\nNOTE: visual condition confirmation is active. "
+                f"The photo analysis suggested condition={report.get('condition_grade')} "
+                f"with confidence={report.get('confidence')}. "
+                "If the seller agrees, call record_attribute with field='condition' "
+                "and that suggested condition value. If they disagree, ask one short "
+                "follow-up question and then call record_attribute with their confirmed "
+                "condition, even if it is unchanged."
+            )
         if item and item.status == ItemStatus.needs_specifics and item.required_specifics:
             specifics = ", ".join(item.required_specifics)
             system_content += (
@@ -448,6 +494,9 @@ async def intake_node(state: IntakeState, config: RunnableConfig) -> dict[str, A
                 terminal_reply = result_text
             elif tc.function.name == "generate_listing":
                 # Non-terminal: let the LLM present the result to the seller
+                pass
+            elif tc.function.name == "analyze_images_for_descriptors":
+                # Non-terminal: let the LLM use the visual summary in the next step.
                 pass
             elif tc.function.name == "mark_intake_complete":
                 terminal_reply = "Great — I have everything I need to prepare your listing!"

--- a/packages/agents/intake/tools.py
+++ b/packages/agents/intake/tools.py
@@ -10,6 +10,7 @@ operations.
 import json
 import logging
 import uuid
+from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -17,7 +18,9 @@ import openai
 from langsmith import traceable
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
+from packages.agents.intake import vision
 from packages.config import settings
 from packages.db.models import Item, ItemCondition, ItemStatus
 
@@ -334,6 +337,21 @@ TOOL_DEFINITIONS = [
     {
         "type": "function",
         "function": {
+            "name": "analyze_images_for_descriptors",
+            "description": (
+                "Analyze uploaded item photos to enrich a thin or generic listing with "
+                "visible descriptors and condition/defect details. Use this when photos "
+                "exist and seller-provided details are too vague, especially for visually "
+                "descriptive or unbranded items such as jewellery, clothing, shoes, watches, "
+                "furniture, bags, or collectibles. Do not use it to claim authenticity, "
+                "precious materials, gemstones, or brand unless visible markings prove them."
+            ),
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "record_item_specific",
             "description": (
                 "Record an eBay item-specific value the seller has supplied. Use ONLY "
@@ -516,8 +534,28 @@ async def execute_tool(
             setattr(item, field, value)
         elif field == "condition":
             try:
+                previous_condition = item.condition
                 # Parse and set condition enum
-                item.condition = ItemCondition(value)
+                new_condition = ItemCondition(value)
+                item.condition = new_condition
+                if item.visual_condition_needs_confirmation and item.visual_condition_report:
+                    attrs = dict(item.attributes or {})
+                    visual_condition = dict(attrs.get("visual_condition") or {})
+                    suggested = item.visual_condition_report.get("condition_grade")
+                    if new_condition.value == suggested:
+                        visual_condition["seller_resolution"] = "accepted_vision"
+                    else:
+                        visual_condition["seller_resolution"] = "seller_disagreed"
+                    visual_condition["vision_suggested_condition"] = suggested
+                    visual_condition["seller_confirmed_condition"] = new_condition.value
+                    visual_condition["previous_seller_condition"] = (
+                        previous_condition.value
+                        if isinstance(previous_condition, ItemCondition)
+                        else str(previous_condition)
+                    )
+                    attrs["visual_condition"] = visual_condition
+                    item.attributes = attrs
+                item.visual_condition_needs_confirmation = False
             except ValueError:
                 valid = [e.value for e in ItemCondition]
                 return (
@@ -560,6 +598,29 @@ async def execute_tool(
 
         await session.flush()
         return f"Saved item-specific {name} = {value!r}", item.id
+
+    if tool_name == "analyze_images_for_descriptors":
+        if not item_id:
+            return "Please tell me what item you're selling before uploading photos.", item_id
+        vision_item = await session.scalar(
+            select(Item).where(Item.id == item_id).options(selectinload(Item.images))
+        )
+        if not vision_item:
+            return "Error: item not found", item_id
+        images = list(getattr(vision_item, "images", []) or [])
+        if not images:
+            return (
+                "Please upload clear photos first so I can use them to improve the listing.",
+                vision_item.id,
+            )
+
+        report = await vision.analyse_item_images(vision_item, images)
+        vision.apply_visual_report_to_item(vision_item, report)
+        vision_item.visual_condition_analyzed_at = datetime.now(UTC)
+        if vision.condition_conflicts_with_seller(vision_item, report):
+            vision_item.visual_condition_needs_confirmation = True
+        await session.flush()
+        return vision.build_tool_summary(report), vision_item.id
 
     if tool_name == "generate_listing":
         raw_title = tool_input["raw_title"]

--- a/packages/agents/intake/tools.py
+++ b/packages/agents/intake/tools.py
@@ -534,28 +534,8 @@ async def execute_tool(
             setattr(item, field, value)
         elif field == "condition":
             try:
-                previous_condition = item.condition
                 # Parse and set condition enum
-                new_condition = ItemCondition(value)
-                item.condition = new_condition
-                if item.visual_condition_needs_confirmation and item.visual_condition_report:
-                    attrs = dict(item.attributes or {})
-                    visual_condition = dict(attrs.get("visual_condition") or {})
-                    suggested = item.visual_condition_report.get("condition_grade")
-                    if new_condition.value == suggested:
-                        visual_condition["seller_resolution"] = "accepted_vision"
-                    else:
-                        visual_condition["seller_resolution"] = "seller_disagreed"
-                    visual_condition["vision_suggested_condition"] = suggested
-                    visual_condition["seller_confirmed_condition"] = new_condition.value
-                    visual_condition["previous_seller_condition"] = (
-                        previous_condition.value
-                        if isinstance(previous_condition, ItemCondition)
-                        else str(previous_condition)
-                    )
-                    attrs["visual_condition"] = visual_condition
-                    item.attributes = attrs
-                item.visual_condition_needs_confirmation = False
+                item.condition = ItemCondition(value)
             except ValueError:
                 valid = [e.value for e in ItemCondition]
                 return (
@@ -617,8 +597,6 @@ async def execute_tool(
         report = await vision.analyse_item_images(vision_item, images)
         vision.apply_visual_report_to_item(vision_item, report)
         vision_item.visual_condition_analyzed_at = datetime.now(UTC)
-        if vision.condition_conflicts_with_seller(vision_item, report):
-            vision_item.visual_condition_needs_confirmation = True
         await session.flush()
         return vision.build_tool_summary(report), vision_item.id
 

--- a/packages/agents/intake/vision.py
+++ b/packages/agents/intake/vision.py
@@ -16,14 +16,6 @@ logger = logging.getLogger(__name__)
 
 _MAX_IMAGES = 6
 _VALID_CONDITIONS = {condition.value for condition in ItemCondition}
-_CONDITION_ORDINAL = {
-    ItemCondition.new.value: 4,
-    ItemCondition.like_new.value: 3,
-    ItemCondition.good.value: 2,
-    ItemCondition.fair.value: 1,
-    ItemCondition.poor.value: 0,
-}
-
 _VISION_SYSTEM = """\
 You inspect seller-uploaded marketplace photos to identify visible item condition.
 Return only valid JSON. Be conservative and factual: mention only defects visible in
@@ -152,31 +144,6 @@ def image_urls_for_analysis(images: list[ItemImage]) -> list[str]:
     """Return ordered image URLs capped to the vision budget."""
     ordered = sorted(images, key=lambda image: image.position)
     return [image.url for image in ordered[:_MAX_IMAGES] if image.url]
-
-
-def condition_conflicts_with_seller(item: Item, report: dict[str, Any]) -> bool:
-    """Return True when vision confidently suggests a lower condition grade."""
-    grade = report.get("condition_grade")
-    if not grade or report.get("photo_quality") == "poor":
-        return False
-    try:
-        confidence = float(report.get("confidence", 0.0))
-    except (TypeError, ValueError):
-        return False
-    if confidence < 0.7:
-        return False
-    seller_grade = str(item.condition) if item.condition else None
-    if seller_grade not in _CONDITION_ORDINAL or grade not in _CONDITION_ORDINAL:
-        return False
-    return _CONDITION_ORDINAL[grade] < _CONDITION_ORDINAL[seller_grade]
-
-
-def build_confirmation_question(report: dict[str, Any]) -> str:
-    grade = report.get("condition_grade") or "used"
-    addendum = report.get("description_addendum") or ""
-    if addendum:
-        return f"The photos appear to show: {addendum} Should I describe the condition as {grade}?"
-    return f"The photos suggest the item may be closer to {grade} condition. Does that sound right?"
 
 
 def append_description_addendum(description: str, addendum: str) -> str:

--- a/packages/agents/intake/vision.py
+++ b/packages/agents/intake/vision.py
@@ -1,0 +1,303 @@
+"""Vision-based condition analysis for intake photos."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+import openai
+from langsmith import traceable
+
+from packages.config import settings
+from packages.db.models import Item, ItemCondition, ItemImage
+
+logger = logging.getLogger(__name__)
+
+_MAX_IMAGES = 6
+_VALID_CONDITIONS = {condition.value for condition in ItemCondition}
+_CONDITION_ORDINAL = {
+    ItemCondition.new.value: 4,
+    ItemCondition.like_new.value: 3,
+    ItemCondition.good.value: 2,
+    ItemCondition.fair.value: 1,
+    ItemCondition.poor.value: 0,
+}
+
+_VISION_SYSTEM = """\
+You inspect seller-uploaded marketplace photos to identify visible item condition.
+Return only valid JSON. Be conservative and factual: mention only defects visible in
+the photos, do not infer hidden faults, and do not invent accessories or damage.
+Use these condition grades only: new, like_new, good, fair, poor.
+"""
+
+
+def _strip_json_fence(text: str) -> str:
+    text = text.strip()
+    if not text.startswith("```"):
+        return text
+    lines = text.splitlines()
+    return "\n".join(line for line in lines if not line.strip().startswith("```")).strip()
+
+
+def _minimal_report(error: str, *, photo_quality: str = "poor") -> dict[str, Any]:
+    return {
+        "condition_grade": None,
+        "confidence": 0.0,
+        "visible_defects": [],
+        "visual_descriptors": [],
+        "photo_quality": photo_quality,
+        "description_addendum": "",
+        "descriptor_addendum": "",
+        "pricing_signals": [],
+        "comparable_include_terms": [],
+        "comparable_exclude_terms": [],
+        "analysis_error": error,
+    }
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(v).strip() for v in value if str(v).strip()]
+
+
+def _normalise_descriptors(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    descriptors: list[dict[str, Any]] = []
+    for entry in value[:20]:
+        if isinstance(entry, str):
+            text = entry.strip()
+            if text:
+                descriptors.append({"name": "visible_detail", "value": text, "confidence": 0.5})
+            continue
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or entry.get("type") or "visible_detail").strip()
+        descriptor: dict[str, Any] = {
+            "name": name,
+            "value": str(entry.get("value") or "").strip(),
+        }
+        if not descriptor["value"]:
+            continue
+        if entry.get("confidence") is not None:
+            try:
+                descriptor["confidence"] = max(0.0, min(float(entry["confidence"]), 1.0))
+            except (TypeError, ValueError):
+                descriptor["confidence"] = 0.5
+        if entry.get("evidence"):
+            descriptor["evidence"] = str(entry["evidence"]).strip()
+        descriptors.append(descriptor)
+    return descriptors
+
+
+def _normalise_report(parsed: Any) -> dict[str, Any]:
+    if not isinstance(parsed, dict):
+        raise ValueError("vision response must be a JSON object")
+
+    grade = parsed.get("condition_grade")
+    if grade is not None:
+        grade = str(grade).strip()
+    if grade not in _VALID_CONDITIONS:
+        grade = None
+
+    try:
+        confidence = float(parsed.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(confidence, 1.0))
+
+    defects = parsed.get("visible_defects")
+    if not isinstance(defects, list):
+        defects = []
+    normalised_defects: list[dict[str, str]] = []
+    for defect in defects[:12]:
+        if not isinstance(defect, dict):
+            continue
+        normalised_defects.append(
+            {
+                "type": str(defect.get("type") or "visible_wear").strip(),
+                "location": str(defect.get("location") or "unknown").strip(),
+                "severity": str(defect.get("severity") or "minor").strip(),
+                "evidence": str(defect.get("evidence") or "").strip(),
+            }
+        )
+
+    photo_quality = str(parsed.get("photo_quality") or "usable").strip().lower()
+    if photo_quality not in {"clear", "usable", "poor"}:
+        photo_quality = "usable"
+
+    return {
+        "condition_grade": grade,
+        "confidence": confidence,
+        "visible_defects": normalised_defects,
+        "visual_descriptors": _normalise_descriptors(parsed.get("visual_descriptors")),
+        "photo_quality": photo_quality,
+        "description_addendum": str(parsed.get("description_addendum") or "").strip(),
+        "descriptor_addendum": str(parsed.get("descriptor_addendum") or "").strip(),
+        "pricing_signals": _coerce_string_list(parsed.get("pricing_signals")),
+        "comparable_include_terms": _coerce_string_list(parsed.get("comparable_include_terms")),
+        "comparable_exclude_terms": _coerce_string_list(parsed.get("comparable_exclude_terms")),
+    }
+
+
+def parse_visual_condition_response(text: str) -> dict[str, Any]:
+    """Parse and normalise the model's JSON condition report."""
+    parsed = json.loads(_strip_json_fence(text))
+    return _normalise_report(parsed)
+
+
+def image_urls_for_analysis(images: list[ItemImage]) -> list[str]:
+    """Return ordered image URLs capped to the vision budget."""
+    ordered = sorted(images, key=lambda image: image.position)
+    return [image.url for image in ordered[:_MAX_IMAGES] if image.url]
+
+
+def condition_conflicts_with_seller(item: Item, report: dict[str, Any]) -> bool:
+    """Return True when vision confidently suggests a lower condition grade."""
+    grade = report.get("condition_grade")
+    if not grade or report.get("photo_quality") == "poor":
+        return False
+    try:
+        confidence = float(report.get("confidence", 0.0))
+    except (TypeError, ValueError):
+        return False
+    if confidence < 0.7:
+        return False
+    seller_grade = str(item.condition) if item.condition else None
+    if seller_grade not in _CONDITION_ORDINAL or grade not in _CONDITION_ORDINAL:
+        return False
+    return _CONDITION_ORDINAL[grade] < _CONDITION_ORDINAL[seller_grade]
+
+
+def build_confirmation_question(report: dict[str, Any]) -> str:
+    grade = report.get("condition_grade") or "used"
+    addendum = report.get("description_addendum") or ""
+    if addendum:
+        return f"The photos appear to show: {addendum} Should I describe the condition as {grade}?"
+    return f"The photos suggest the item may be closer to {grade} condition. Does that sound right?"
+
+
+def append_description_addendum(description: str, addendum: str) -> str:
+    """Append a short visible-condition note without duplicating it."""
+    clean = addendum.strip()
+    if not clean:
+        return description
+    if clean.lower() in (description or "").lower():
+        return description
+    prefix = "Visible condition note: "
+    note = clean if clean.lower().startswith(prefix.lower()) else f"{prefix}{clean}"
+    if description and description.strip():
+        return f"{description.rstrip()}\n\n{note}"
+    return note
+
+
+def apply_visual_report_to_item(item: Item, report: dict[str, Any]) -> None:
+    """Persist normalised vision output onto an Item instance."""
+    item.visual_condition_report = report
+
+    attrs = dict(item.attributes or {})
+    existing_condition = dict(attrs.get("visual_condition") or {})
+    existing_condition.update(
+        {
+            "condition_grade": report.get("condition_grade"),
+            "confidence": report.get("confidence", 0.0),
+            "photo_quality": report.get("photo_quality"),
+            "visible_defects": report.get("visible_defects", []),
+            "pricing_signals": report.get("pricing_signals", []),
+            "comparable_include_terms": report.get("comparable_include_terms", []),
+            "comparable_exclude_terms": report.get("comparable_exclude_terms", []),
+        }
+    )
+    attrs["visual_condition"] = existing_condition
+    attrs["visual_descriptors"] = report.get("visual_descriptors", [])
+    item.attributes = attrs
+
+    description = append_description_addendum(
+        item.description or "", str(report.get("description_addendum") or "")
+    )
+    item.description = append_description_addendum(
+        description, str(report.get("descriptor_addendum") or "")
+    )
+
+
+def build_tool_summary(report: dict[str, Any]) -> str:
+    descriptors = report.get("visual_descriptors") or []
+    descriptor_bits = [
+        f"{d.get('name')}: {d.get('value')}" for d in descriptors if isinstance(d, dict)
+    ][:8]
+    defects = report.get("visible_defects") or []
+    defect_bits = [
+        f"{d.get('severity', 'visible')} {d.get('type', 'wear')} at {d.get('location', 'unknown')}"
+        for d in defects
+        if isinstance(d, dict)
+    ][:6]
+
+    lines = [
+        "Visual analysis saved.",
+        f"Suggested condition: {report.get('condition_grade') or 'unknown'} "
+        f"(confidence {report.get('confidence', 0.0)}).",
+    ]
+    if descriptor_bits:
+        lines.append("Visible descriptors: " + "; ".join(descriptor_bits))
+    if defect_bits:
+        lines.append("Visible defects: " + "; ".join(defect_bits))
+    if report.get("description_addendum") or report.get("descriptor_addendum"):
+        lines.append("Description was enriched with factual visual notes.")
+    return "\n".join(lines)
+
+
+@traceable(name="intake_visual_condition_analysis", run_type="llm")
+async def analyse_item_images(item: Item, images: list[ItemImage]) -> dict[str, Any]:
+    """Call the vision model and return a normalised condition report."""
+    image_urls = image_urls_for_analysis(images)
+    if not image_urls:
+        return _minimal_report("no_images")
+
+    detail = "low" if item.condition == ItemCondition.like_new else "high"
+    content: list[dict[str, Any]] = [
+        {
+            "type": "input_text",
+            "text": (
+                "Analyze these marketplace listing photos for visible listing descriptors "
+                "and visible condition only. "
+                f"Seller-stated condition: {item.condition}. "
+                f"Title: {item.name or ''}. Category: {item.category or ''}. "
+                "Return JSON with keys: condition_grade, confidence, visible_defects, "
+                "visual_descriptors, photo_quality, description_addendum, descriptor_addendum, "
+                "pricing_signals, comparable_include_terms, comparable_exclude_terms. "
+                "For descriptors, include visible attributes such as colour, shape, style, "
+                "pattern, markings, accessories, and distinguishing features. Use cautious "
+                "language like silver-tone or clear stones unless material/authenticity is "
+                "visibly proven."
+            ),
+        }
+    ]
+    content.extend(
+        {"type": "input_image", "image_url": url, "detail": detail} for url in image_urls
+    )
+
+    try:
+        client = openai.AsyncOpenAI(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url or None,
+            timeout=30.0,
+        )
+        response_input = cast(
+            Any,
+            [
+                {"role": "system", "content": _VISION_SYSTEM},
+                {"role": "user", "content": content},
+            ],
+        )
+        response = await client.responses.create(
+            model=settings.model_intake_vision,
+            input=response_input,
+            temperature=0.1,
+        )
+        text = getattr(response, "output_text", "") or ""
+        return parse_visual_condition_response(text)
+    except Exception as exc:
+        logger.exception("Intake vision analysis failed")
+        return _minimal_report(type(exc).__name__)

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -153,10 +153,6 @@ _CONDITION_MAP: dict[ItemCondition, int] = {
     ItemCondition.fair: 1,  # used
     ItemCondition.poor: 0,  # for_parts
 }
-_CONDITION_ORDINAL_BY_VALUE = {condition.value: ordinal for condition, ordinal in _CONDITION_MAP.items()}
-_VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER = 0.85
-
-
 def _condition_ord(item: Item) -> int:
     return _CONDITION_MAP.get(item.condition, 2)
 
@@ -196,57 +192,8 @@ def _visual_condition_context(item: Item) -> str:
         values = report.get(key) or visual_attrs.get(key) or []
         if values:
             parts.append(f"{label}: {', '.join(str(v) for v in values[:8])}")
-    resolution = visual_attrs.get("seller_resolution")
-    if resolution:
-        parts.append(f"seller resolution: {resolution}")
 
     return ". ".join(parts)
-
-
-def _has_high_confidence_visual_condition_disagreement(item: Item) -> bool:
-    report = item.visual_condition_report or {}
-    visual_attrs = (item.attributes or {}).get("visual_condition", {})
-    if visual_attrs.get("seller_resolution") != "seller_disagreed":
-        return False
-    if (report.get("photo_quality") or visual_attrs.get("photo_quality")) == "poor":
-        return False
-
-    try:
-        vision_confidence = float(report.get("confidence", visual_attrs.get("confidence", 0.0)))
-    except (TypeError, ValueError):
-        return False
-    if vision_confidence < 0.75:
-        return False
-
-    vision_grade = report.get("condition_grade") or visual_attrs.get("vision_suggested_condition")
-    seller_grade = visual_attrs.get("seller_confirmed_condition") or (
-        item.condition.value if isinstance(item.condition, ItemCondition) else str(item.condition)
-    )
-    if vision_grade not in _CONDITION_ORDINAL_BY_VALUE or seller_grade not in _CONDITION_ORDINAL_BY_VALUE:
-        return False
-    return _CONDITION_ORDINAL_BY_VALUE[str(vision_grade)] < _CONDITION_ORDINAL_BY_VALUE[
-        str(seller_grade)
-    ]
-
-
-def _apply_visual_condition_confidence_adjustment(
-    item: Item,
-    confidence: float,
-) -> tuple[float, dict[str, Any]]:
-    """Lower confidence, not price, when seller rejects high-confidence photo evidence."""
-    visual_condition = (item.attributes or {}).get("visual_condition", {})
-    if not isinstance(visual_condition, dict):
-        visual_condition = {}
-    adjustment = {
-        "visual_condition_seller_resolution": visual_condition.get("seller_resolution"),
-        "visual_condition_confidence_penalty": 1.0,
-    }
-    if not _has_high_confidence_visual_condition_disagreement(item):
-        return confidence, adjustment
-
-    adjusted = confidence * _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
-    adjustment["visual_condition_confidence_penalty"] = _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
-    return adjusted, adjustment
 
 
 # ---------------------------------------------------------------------------
@@ -653,11 +600,6 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
         confidence = 0.3
     else:
         confidence = 0.0
-    confidence, confidence_adjustment = _apply_visual_condition_confidence_adjustment(
-        row, confidence
-    )
-    if model_features is not None:
-        model_features.update({f"_context_{k}": v for k, v in confidence_adjustment.items()})
 
     floor = (
         float(row.seller_floor_price)

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -153,10 +153,100 @@ _CONDITION_MAP: dict[ItemCondition, int] = {
     ItemCondition.fair: 1,  # used
     ItemCondition.poor: 0,  # for_parts
 }
+_CONDITION_ORDINAL_BY_VALUE = {condition.value: ordinal for condition, ordinal in _CONDITION_MAP.items()}
+_VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER = 0.85
 
 
 def _condition_ord(item: Item) -> int:
     return _CONDITION_MAP.get(item.condition, 2)
+
+
+def _visual_condition_context(item: Item) -> str:
+    """Compact vision-derived condition context for comparable search/filtering."""
+    report = item.visual_condition_report or {}
+    visual_attrs = (item.attributes or {}).get("visual_condition", {})
+    parts: list[str] = []
+
+    grade = report.get("condition_grade") or visual_attrs.get("condition_grade")
+    confidence = report.get("confidence", visual_attrs.get("confidence"))
+    if grade:
+        parts.append(f"vision grade: {grade}")
+    if confidence is not None:
+        parts.append(f"confidence: {confidence}")
+
+    defects = report.get("visible_defects") or visual_attrs.get("visible_defects") or []
+    defect_bits = []
+    for defect in defects[:4]:
+        if not isinstance(defect, dict):
+            continue
+        severity = defect.get("severity")
+        defect_type = defect.get("type")
+        location = defect.get("location")
+        bit = " ".join(str(v) for v in (severity, defect_type, location) if v)
+        if bit:
+            defect_bits.append(bit)
+    if defect_bits:
+        parts.append("visible defects: " + "; ".join(defect_bits))
+
+    for key, label in (
+        ("pricing_signals", "pricing signals"),
+        ("comparable_include_terms", "prefer comps with"),
+        ("comparable_exclude_terms", "avoid comps with"),
+    ):
+        values = report.get(key) or visual_attrs.get(key) or []
+        if values:
+            parts.append(f"{label}: {', '.join(str(v) for v in values[:8])}")
+    resolution = visual_attrs.get("seller_resolution")
+    if resolution:
+        parts.append(f"seller resolution: {resolution}")
+
+    return ". ".join(parts)
+
+
+def _has_high_confidence_visual_condition_disagreement(item: Item) -> bool:
+    report = item.visual_condition_report or {}
+    visual_attrs = (item.attributes or {}).get("visual_condition", {})
+    if visual_attrs.get("seller_resolution") != "seller_disagreed":
+        return False
+    if (report.get("photo_quality") or visual_attrs.get("photo_quality")) == "poor":
+        return False
+
+    try:
+        vision_confidence = float(report.get("confidence", visual_attrs.get("confidence", 0.0)))
+    except (TypeError, ValueError):
+        return False
+    if vision_confidence < 0.75:
+        return False
+
+    vision_grade = report.get("condition_grade") or visual_attrs.get("vision_suggested_condition")
+    seller_grade = visual_attrs.get("seller_confirmed_condition") or (
+        item.condition.value if isinstance(item.condition, ItemCondition) else str(item.condition)
+    )
+    if vision_grade not in _CONDITION_ORDINAL_BY_VALUE or seller_grade not in _CONDITION_ORDINAL_BY_VALUE:
+        return False
+    return _CONDITION_ORDINAL_BY_VALUE[str(vision_grade)] < _CONDITION_ORDINAL_BY_VALUE[
+        str(seller_grade)
+    ]
+
+
+def _apply_visual_condition_confidence_adjustment(
+    item: Item,
+    confidence: float,
+) -> tuple[float, dict[str, Any]]:
+    """Lower confidence, not price, when seller rejects high-confidence photo evidence."""
+    visual_condition = (item.attributes or {}).get("visual_condition", {})
+    if not isinstance(visual_condition, dict):
+        visual_condition = {}
+    adjustment = {
+        "visual_condition_seller_resolution": visual_condition.get("seller_resolution"),
+        "visual_condition_confidence_penalty": 1.0,
+    }
+    if not _has_high_confidence_visual_condition_disagreement(item):
+        return confidence, adjustment
+
+    adjusted = confidence * _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
+    adjustment["visual_condition_confidence_penalty"] = _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
+    return adjusted, adjustment
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +415,10 @@ async def _collect_comparables(
     """
     brand = (item.attributes or {}).get("brand") if item.attributes else None
     condition = str(item.condition) if item.condition else None
+    visual_context = _visual_condition_context(item)
+    search_description = item.description
+    if visual_context:
+        search_description = f"{item.description or ''}\nPhoto condition analysis: {visual_context}"
 
     # Resolve eBay category ID once — used across all rounds for category filtering
     category_id: str | None = None
@@ -369,7 +463,7 @@ async def _collect_comparables(
                 condition=search_condition,
                 limit=fetch_limit,
                 brand=brand,
-                description=item.description,
+                description=search_description,
                 query_override=query_override,
                 category_id=category_id,
             )
@@ -390,8 +484,9 @@ async def _collect_comparables(
             item_title=item.name or "",
             item_category=item.category or "",
             item_brand=brand,
-            item_description=item.description or "",
+            item_description=search_description or "",
             comparables=new_candidates,
+            visual_condition_context=visual_context or None,
         )
 
         kept.extend(valid)
@@ -531,6 +626,9 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
 
     # Get price prediction from historical ML model
     model_pred, model_features = _model_predict(row, prices)
+    visual_context = _visual_condition_context(row)
+    if model_features is not None and visual_context:
+        model_features["_context_visual_condition"] = visual_context
 
     # Blend the model prediction with the live comparable median, tapering the
     # median's weight when too few comparables were found to trust it.
@@ -555,6 +653,11 @@ async def run(item_id: uuid.UUID, seller_id: uuid.UUID, session: AsyncSession) -
         confidence = 0.3
     else:
         confidence = 0.0
+    confidence, confidence_adjustment = _apply_visual_condition_confidence_adjustment(
+        row, confidence
+    )
+    if model_features is not None:
+        model_features.update({f"_context_{k}": v for k, v in confidence_adjustment.items()})
 
     floor = (
         float(row.seller_floor_price)

--- a/packages/agents/pricing/agent.py
+++ b/packages/agents/pricing/agent.py
@@ -153,6 +153,8 @@ _CONDITION_MAP: dict[ItemCondition, int] = {
     ItemCondition.fair: 1,  # used
     ItemCondition.poor: 0,  # for_parts
 }
+
+
 def _condition_ord(item: Item) -> int:
     return _CONDITION_MAP.get(item.condition, 2)
 

--- a/packages/agents/pricing/comparable_filter.py
+++ b/packages/agents/pricing/comparable_filter.py
@@ -127,6 +127,7 @@ async def validate_comparables(
     item_brand: str | None,
     item_description: str,
     comparables: list[Comparable],
+    visual_condition_context: str | None = None,
 ) -> tuple[list[Comparable], list[Comparable]]:
     """LLM-gate that classifies comparables as keep/reject for a given item.
 
@@ -160,6 +161,8 @@ async def validate_comparables(
         # Limit description to first 60 words to keep the prompt compact
         short_desc = " ".join(item_description.split()[:60])
         item_ctx += f"  Description: {short_desc}\n"
+    if visual_condition_context:
+        item_ctx += f"  Photo condition analysis: {visual_condition_context}\n"
 
     comp_lines = "\n".join(
         f'{i + 1}. "{comp.title}" — £{comp.price:.2f}' for i, comp in enumerate(heuristic_kept)

--- a/packages/config.py
+++ b/packages/config.py
@@ -53,7 +53,6 @@ class Settings(BaseSettings):
     model_agent3: str = "gpt-4.1-mini"  # eBay item-specifics inference for the publisher
     model_agent4: str = "gpt-4.1-mini"
     model_intake_vision: str = "gpt-4.1-mini"
-    intake_vision_enabled: bool = True
 
     jwt_secret_key: str = ""
     jwt_algorithm: str = "HS256"

--- a/packages/config.py
+++ b/packages/config.py
@@ -52,6 +52,8 @@ class Settings(BaseSettings):
     model_agent2: str = "gpt-4.1-mini"  # relevance filter LLM for pricing comparables
     model_agent3: str = "gpt-4.1-mini"  # eBay item-specifics inference for the publisher
     model_agent4: str = "gpt-4.1-mini"
+    model_intake_vision: str = "gpt-4.1-mini"
+    intake_vision_enabled: bool = True
 
     jwt_secret_key: str = ""
     jwt_algorithm: str = "HS256"

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -245,9 +245,6 @@ class Item(Base):
     # Vision-derived condition analysis from uploaded item photos.
     visual_condition_report: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
     visual_condition_analyzed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    visual_condition_needs_confirmation: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=False, server_default="false"
-    )
 
     # Minimum acceptable price from seller
     seller_floor_price: Mapped[float | None] = mapped_column(Numeric(12, 2))

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -242,6 +242,13 @@ class Item(Base):
     # NOTE: default=dict is safe here because SQLAlchemy handles callable defaults
     attributes: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, default=dict)
 
+    # Vision-derived condition analysis from uploaded item photos.
+    visual_condition_report: Mapped[dict[str, Any] | None] = mapped_column(JSONB)
+    visual_condition_analyzed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    visual_condition_needs_confirmation: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+
     # Minimum acceptable price from seller
     seller_floor_price: Mapped[float | None] = mapped_column(Numeric(12, 2))
 

--- a/tests/test_intake_graph.py
+++ b/tests/test_intake_graph.py
@@ -1,6 +1,5 @@
 import json
 import uuid
-from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -194,31 +193,7 @@ async def test_plan_next_step_completes_once_minimum_images_uploaded():
 
 
 @pytest.mark.asyncio
-async def test_plan_next_step_skips_vision_for_new_condition(monkeypatch):
-    item_id = uuid.uuid4()
-    seller_id = uuid.uuid4()
-    item = Item(
-        id=item_id,
-        seller_id=seller_id,
-        name="Sealed Apple AirPods",
-        category="Headphones",
-        condition=ItemCondition.new,
-        description="Brand new sealed AirPods.",
-    )
-    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
-    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
-
-    analyse = AsyncMock()
-    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
-
-    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
-
-    assert complete is True
-    analyse.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_plan_next_step_stores_vision_report_and_appends_description(monkeypatch):
+async def test_plan_next_step_does_not_call_vision_automatically(monkeypatch):
     item_id = uuid.uuid4()
     seller_id = uuid.uuid4()
     item = Item(
@@ -232,126 +207,8 @@ async def test_plan_next_step_stores_vision_report_and_appends_description(monke
     item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
     session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
 
-    monkeypatch.setattr(
-        "packages.agents.intake.graph.vision.analyse_item_images",
-        AsyncMock(
-            return_value={
-                "condition_grade": "good",
-                "confidence": 0.83,
-                "visible_defects": [{"type": "scuff", "severity": "minor"}],
-                "photo_quality": "clear",
-                "description_addendum": "Minor scuffing is visible on the sole.",
-                "pricing_signals": ["sole_wear"],
-                "comparable_include_terms": ["used good"],
-                "comparable_exclude_terms": ["new", "sealed"],
-            }
-        ),
-    )
-
-    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
-
-    assert complete is True
-    assert item.visual_condition_report["condition_grade"] == "good"
-    assert item.attributes["visual_condition"]["pricing_signals"] == ["sole_wear"]
-    assert "Minor scuffing" in item.description
-
-
-@pytest.mark.asyncio
-async def test_plan_next_step_asks_for_confirmation_on_condition_conflict(monkeypatch):
-    item_id = uuid.uuid4()
-    seller_id = uuid.uuid4()
-    item = Item(
-        id=item_id,
-        seller_id=seller_id,
-        name="Nike Air Max 90",
-        category="Trainers",
-        condition=ItemCondition.like_new,
-        description="Nike Air Max 90 trainers in like new condition.",
-    )
-    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
-    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
-
-    monkeypatch.setattr(
-        "packages.agents.intake.graph.vision.analyse_item_images",
-        AsyncMock(
-            return_value={
-                "condition_grade": "good",
-                "confidence": 0.91,
-                "visible_defects": [{"type": "scuff", "severity": "minor"}],
-                "photo_quality": "clear",
-                "description_addendum": "Minor scuffing is visible on the sole.",
-                "pricing_signals": ["sole_wear"],
-                "comparable_include_terms": ["used good"],
-                "comparable_exclude_terms": ["new", "sealed"],
-            }
-        ),
-    )
-
-    reply, needs_image, complete = await _plan_next_step(session, item.id)
-
-    assert "good" in reply
-    assert needs_image is False
-    assert complete is False
-    assert item.visual_condition_needs_confirmation is True
-
-
-@pytest.mark.asyncio
-async def test_plan_next_step_completes_when_vision_fails(monkeypatch):
-    item_id = uuid.uuid4()
-    seller_id = uuid.uuid4()
-    item = Item(
-        id=item_id,
-        seller_id=seller_id,
-        name="Nike Air Max 90",
-        category="Trainers",
-        condition=ItemCondition.good,
-        description="Nike Air Max 90 trainers in good condition.",
-    )
-    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
-    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
-
-    monkeypatch.setattr(
-        "packages.agents.intake.graph.vision.analyse_item_images",
-        AsyncMock(
-            return_value={
-                "condition_grade": None,
-                "confidence": 0.0,
-                "visible_defects": [],
-                "photo_quality": "poor",
-                "description_addendum": "",
-                "pricing_signals": [],
-                "comparable_include_terms": [],
-                "comparable_exclude_terms": [],
-                "analysis_error": "RuntimeError",
-            }
-        ),
-    )
-
-    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
-
-    assert complete is True
-    assert item.visual_condition_report["analysis_error"] == "RuntimeError"
-
-
-@pytest.mark.asyncio
-async def test_plan_next_step_skips_final_vision_when_tool_already_ran(monkeypatch):
-    item_id = uuid.uuid4()
-    seller_id = uuid.uuid4()
-    item = Item(
-        id=item_id,
-        seller_id=seller_id,
-        name="Unbranded ring",
-        category="Jewellery",
-        condition=ItemCondition.good,
-        description="Unbranded ring with silver-tone band.",
-        visual_condition_analyzed_at=datetime.now(UTC),
-        attributes={"visual_descriptors": [{"name": "colour", "value": "silver-tone"}]},
-    )
-    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
-    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
-
     analyse = AsyncMock()
-    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
+    monkeypatch.setattr("packages.agents.intake.tools.vision.analyse_item_images", analyse)
 
     _reply, _needs_image, complete = await _plan_next_step(session, item.id)
 
@@ -468,39 +325,6 @@ async def test_record_attribute_saves_brand():
 
     assert "Saved brand" in result_text
     assert item.brand == "Nike"
-
-
-@pytest.mark.asyncio
-async def test_record_attribute_tracks_seller_disagreement_with_visual_condition():
-    item_id = uuid.uuid4()
-    seller_id = uuid.uuid4()
-    item = Item(
-        id=item_id,
-        seller_id=seller_id,
-        name="Nike Air Max 90",
-        category="Trainers",
-        condition=ItemCondition.like_new,
-        description="Like new trainers.",
-        visual_condition_needs_confirmation=True,
-        visual_condition_report={"condition_grade": "good", "confidence": 0.9},
-        attributes={"visual_condition": {"condition_grade": "good", "confidence": 0.9}},
-    )
-    session = _FakeSession(item=item)
-
-    result_text, _ = await execute_tool(
-        tool_name="record_attribute",
-        tool_input={"field": "condition", "value": "like_new"},
-        seller_id=seller_id,
-        item_id=item_id,
-        session=session,
-    )
-
-    visual_condition = item.attributes["visual_condition"]
-    assert "Saved condition" in result_text
-    assert item.visual_condition_needs_confirmation is False
-    assert visual_condition["seller_resolution"] == "seller_disagreed"
-    assert visual_condition["vision_suggested_condition"] == "good"
-    assert visual_condition["seller_confirmed_condition"] == "like_new"
 
 
 @pytest.mark.asyncio

--- a/tests/test_intake_graph.py
+++ b/tests/test_intake_graph.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -15,7 +16,7 @@ from packages.agents.intake.tools import (
     _generate_listing_text,
     execute_tool,
 )
-from packages.db.models import Item, ItemCondition
+from packages.db.models import Item, ItemCondition, ItemImage
 
 
 class _FakeCompletions:
@@ -59,6 +60,17 @@ class _FakeSession:
 
     def add(self, obj):
         self.added.append(obj)
+
+
+def _make_image(item_id: uuid.UUID, seller_id: uuid.UUID, position: int) -> ItemImage:
+    return ItemImage(
+        id=uuid.uuid4(),
+        item_id=item_id,
+        seller_id=seller_id,
+        s3_key=f"items/{position}.jpg",
+        url=f"https://example.com/{position}.jpg",
+        position=position,
+    )
 
 
 # ── Existing tests (updated for v2) ──────────────────────────────────────
@@ -182,6 +194,172 @@ async def test_plan_next_step_completes_once_minimum_images_uploaded():
 
 
 @pytest.mark.asyncio
+async def test_plan_next_step_skips_vision_for_new_condition(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Sealed Apple AirPods",
+        category="Headphones",
+        condition=ItemCondition.new,
+        description="Brand new sealed AirPods.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
+    analyse = AsyncMock()
+    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
+
+    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert complete is True
+    analyse.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_plan_next_step_stores_vision_report_and_appends_description(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.good,
+        description="Nike Air Max 90 trainers in good condition.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
+    monkeypatch.setattr(
+        "packages.agents.intake.graph.vision.analyse_item_images",
+        AsyncMock(
+            return_value={
+                "condition_grade": "good",
+                "confidence": 0.83,
+                "visible_defects": [{"type": "scuff", "severity": "minor"}],
+                "photo_quality": "clear",
+                "description_addendum": "Minor scuffing is visible on the sole.",
+                "pricing_signals": ["sole_wear"],
+                "comparable_include_terms": ["used good"],
+                "comparable_exclude_terms": ["new", "sealed"],
+            }
+        ),
+    )
+
+    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert complete is True
+    assert item.visual_condition_report["condition_grade"] == "good"
+    assert item.attributes["visual_condition"]["pricing_signals"] == ["sole_wear"]
+    assert "Minor scuffing" in item.description
+
+
+@pytest.mark.asyncio
+async def test_plan_next_step_asks_for_confirmation_on_condition_conflict(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.like_new,
+        description="Nike Air Max 90 trainers in like new condition.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
+    monkeypatch.setattr(
+        "packages.agents.intake.graph.vision.analyse_item_images",
+        AsyncMock(
+            return_value={
+                "condition_grade": "good",
+                "confidence": 0.91,
+                "visible_defects": [{"type": "scuff", "severity": "minor"}],
+                "photo_quality": "clear",
+                "description_addendum": "Minor scuffing is visible on the sole.",
+                "pricing_signals": ["sole_wear"],
+                "comparable_include_terms": ["used good"],
+                "comparable_exclude_terms": ["new", "sealed"],
+            }
+        ),
+    )
+
+    reply, needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert "good" in reply
+    assert needs_image is False
+    assert complete is False
+    assert item.visual_condition_needs_confirmation is True
+
+
+@pytest.mark.asyncio
+async def test_plan_next_step_completes_when_vision_fails(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.good,
+        description="Nike Air Max 90 trainers in good condition.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
+    monkeypatch.setattr(
+        "packages.agents.intake.graph.vision.analyse_item_images",
+        AsyncMock(
+            return_value={
+                "condition_grade": None,
+                "confidence": 0.0,
+                "visible_defects": [],
+                "photo_quality": "poor",
+                "description_addendum": "",
+                "pricing_signals": [],
+                "comparable_include_terms": [],
+                "comparable_exclude_terms": [],
+                "analysis_error": "RuntimeError",
+            }
+        ),
+    )
+
+    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert complete is True
+    assert item.visual_condition_report["analysis_error"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_plan_next_step_skips_final_vision_when_tool_already_ran(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Unbranded ring",
+        category="Jewellery",
+        condition=ItemCondition.good,
+        description="Unbranded ring with silver-tone band.",
+        visual_condition_analyzed_at=datetime.now(UTC),
+        attributes={"visual_descriptors": [{"name": "colour", "value": "silver-tone"}]},
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
+    analyse = AsyncMock()
+    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
+
+    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert complete is True
+    analyse.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_intake_node_uses_local_planner_after_tool_execution(monkeypatch):
     tool_call = SimpleNamespace(
         id="call_1",
@@ -290,6 +468,110 @@ async def test_record_attribute_saves_brand():
 
     assert "Saved brand" in result_text
     assert item.brand == "Nike"
+
+
+@pytest.mark.asyncio
+async def test_record_attribute_tracks_seller_disagreement_with_visual_condition():
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.like_new,
+        description="Like new trainers.",
+        visual_condition_needs_confirmation=True,
+        visual_condition_report={"condition_grade": "good", "confidence": 0.9},
+        attributes={"visual_condition": {"condition_grade": "good", "confidence": 0.9}},
+    )
+    session = _FakeSession(item=item)
+
+    result_text, _ = await execute_tool(
+        tool_name="record_attribute",
+        tool_input={"field": "condition", "value": "like_new"},
+        seller_id=seller_id,
+        item_id=item_id,
+        session=session,
+    )
+
+    visual_condition = item.attributes["visual_condition"]
+    assert "Saved condition" in result_text
+    assert item.visual_condition_needs_confirmation is False
+    assert visual_condition["seller_resolution"] == "seller_disagreed"
+    assert visual_condition["vision_suggested_condition"] == "good"
+    assert visual_condition["seller_confirmed_condition"] == "like_new"
+
+
+@pytest.mark.asyncio
+async def test_analyze_images_for_descriptors_tool_stores_report(monkeypatch):
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Unbranded ring",
+        category="Jewellery",
+        condition=ItemCondition.good,
+        description="Unbranded ring.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(2)]
+    session = _FakeSession(item=item)
+    monkeypatch.setattr(
+        "packages.agents.intake.tools.vision.analyse_item_images",
+        AsyncMock(
+            return_value={
+                "condition_grade": "good",
+                "confidence": 0.8,
+                "visible_defects": [],
+                "visual_descriptors": [{"name": "metal colour", "value": "silver-tone"}],
+                "photo_quality": "clear",
+                "description_addendum": "Light surface wear is visible.",
+                "descriptor_addendum": "Silver-tone band with clear stones visible.",
+                "pricing_signals": ["silver_tone"],
+                "comparable_include_terms": ["silver-tone ring"],
+                "comparable_exclude_terms": ["gold ring"],
+            }
+        ),
+    )
+
+    result_text, _ = await execute_tool(
+        tool_name="analyze_images_for_descriptors",
+        tool_input={},
+        seller_id=seller_id,
+        item_id=item_id,
+        session=session,
+    )
+
+    assert "Visual analysis saved" in result_text
+    assert item.attributes["visual_descriptors"][0]["value"] == "silver-tone"
+    assert "Silver-tone band" in item.description
+
+
+@pytest.mark.asyncio
+async def test_analyze_images_for_descriptors_tool_requires_images():
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Unbranded ring",
+        category="Jewellery",
+        condition=ItemCondition.good,
+        description="Unbranded ring.",
+    )
+    item.images = []
+    session = _FakeSession(item=item)
+
+    result_text, _ = await execute_tool(
+        tool_name="analyze_images_for_descriptors",
+        tool_input={},
+        seller_id=seller_id,
+        item_id=item_id,
+        session=session,
+    )
+
+    assert "upload clear photos first" in result_text
 
 
 # ── New v2 tests — generate_listing tool ─────────────────────────────────

--- a/tests/test_intake_vision.py
+++ b/tests/test_intake_vision.py
@@ -1,0 +1,147 @@
+import json
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from packages.agents.intake import vision
+from packages.db.models import Item, ItemCondition, ItemImage
+
+
+def _image(position: int) -> ItemImage:
+    return ItemImage(
+        id=uuid.uuid4(),
+        item_id=uuid.uuid4(),
+        seller_id=uuid.uuid4(),
+        s3_key=f"items/{position}.jpg",
+        url=f"https://example.com/{position}.jpg",
+        position=position,
+    )
+
+
+def test_parse_visual_condition_response_handles_fenced_json():
+    raw = """```json
+{"condition_grade":"good","confidence":0.82,"visible_defects":[{"type":"scuff","location":"heel","severity":"minor","evidence":"light wear"}],"visual_descriptors":[{"name":"metal colour","value":"silver-tone","confidence":0.7}],"photo_quality":"clear","description_addendum":"Minor heel scuffing is visible.","descriptor_addendum":"Silver-tone band with clear stones visible.","pricing_signals":["minor_scuffs"],"comparable_include_terms":["used good"],"comparable_exclude_terms":["new","sealed"]}
+```"""
+
+    report = vision.parse_visual_condition_response(raw)
+
+    assert report["condition_grade"] == "good"
+    assert report["confidence"] == pytest.approx(0.82)
+    assert report["visible_defects"][0]["type"] == "scuff"
+    assert report["visual_descriptors"][0]["value"] == "silver-tone"
+    assert report["descriptor_addendum"] == "Silver-tone band with clear stones visible."
+    assert report["comparable_exclude_terms"] == ["new", "sealed"]
+
+
+def test_image_urls_for_analysis_caps_and_orders_images():
+    images = [_image(i) for i in [8, 2, 4, 1, 7, 3, 5, 6]]
+
+    urls = vision.image_urls_for_analysis(images)
+
+    assert urls == [f"https://example.com/{i}.jpg" for i in [1, 2, 3, 4, 5, 6]]
+
+
+@pytest.mark.asyncio
+async def test_analyse_item_images_handles_invalid_json(monkeypatch):
+    class FakeResponses:
+        async def create(self, **kwargs):
+            return SimpleNamespace(output_text="not json")
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr("packages.agents.intake.vision.openai.AsyncOpenAI", FakeClient)
+
+    item = Item(
+        id=uuid.uuid4(),
+        seller_id=uuid.uuid4(),
+        name="Nike trainers",
+        category="Trainers",
+        condition=ItemCondition.good,
+        description="Good condition.",
+    )
+
+    report = await vision.analyse_item_images(item, [_image(0)])
+
+    assert report["confidence"] == 0.0
+    assert report["analysis_error"] == "JSONDecodeError"
+
+
+@pytest.mark.asyncio
+async def test_analyse_item_images_sends_ordered_capped_urls(monkeypatch):
+    captured = {}
+
+    class FakeResponses:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                output_text=json.dumps(
+                    {
+                        "condition_grade": "good",
+                        "confidence": 0.8,
+                        "visible_defects": [],
+                        "photo_quality": "usable",
+                        "description_addendum": "",
+                        "pricing_signals": [],
+                        "comparable_include_terms": [],
+                        "comparable_exclude_terms": [],
+                    }
+                )
+            )
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr("packages.agents.intake.vision.openai.AsyncOpenAI", FakeClient)
+
+    item = Item(
+        id=uuid.uuid4(),
+        seller_id=uuid.uuid4(),
+        name="Nike trainers",
+        category="Trainers",
+        condition=ItemCondition.good,
+        description="Good condition.",
+    )
+    images = [_image(i) for i in [9, 0, 2, 4, 1, 3, 5]]
+
+    await vision.analyse_item_images(item, images)
+
+    user_content = captured["input"][1]["content"]
+    image_urls = [part["image_url"] for part in user_content if part["type"] == "input_image"]
+    assert image_urls == [f"https://example.com/{i}.jpg" for i in [0, 1, 2, 3, 4, 5]]
+
+
+def test_apply_visual_report_to_item_stores_descriptors_and_appends_notes():
+    item = Item(
+        id=uuid.uuid4(),
+        seller_id=uuid.uuid4(),
+        name="Unbranded ring",
+        category="Jewellery",
+        condition=ItemCondition.good,
+        description="Unbranded ring.",
+    )
+    report = {
+        "condition_grade": "good",
+        "confidence": 0.84,
+        "visible_defects": [],
+        "visual_descriptors": [
+            {"name": "metal colour", "value": "silver-tone", "confidence": 0.75}
+        ],
+        "photo_quality": "clear",
+        "description_addendum": "Light surface wear is visible.",
+        "descriptor_addendum": "Silver-tone band with clear stones visible.",
+        "pricing_signals": ["silver_tone"],
+        "comparable_include_terms": ["silver-tone ring"],
+        "comparable_exclude_terms": ["gold ring"],
+    }
+
+    vision.apply_visual_report_to_item(item, report)
+
+    assert item.visual_condition_report == report
+    assert item.attributes["visual_descriptors"][0]["value"] == "silver-tone"
+    assert item.attributes["visual_condition"]["pricing_signals"] == ["silver_tone"]
+    assert "Light surface wear" in item.description
+    assert "Silver-tone band" in item.description

--- a/tests/test_pricing_agent.py
+++ b/tests/test_pricing_agent.py
@@ -1,16 +1,10 @@
-import uuid
 from unittest.mock import patch
 
 import pytest
 
 from packages.agents.pricing import agent
-from packages.agents.pricing.agent import (
-    _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER,
-    _apply_visual_condition_confidence_adjustment,
-    _blend_price,
-)
+from packages.agents.pricing.agent import _blend_price
 from packages.agents.pricing.comparable_filter import validate_comparables
-from packages.db.models import Item, ItemCondition
 from packages.platform_adapters.ebay.browse import Comparable
 
 
@@ -113,71 +107,3 @@ async def test_validate_comparables_includes_visual_condition_context(monkeypatc
     user_message = captured["messages"][1]["content"]
     assert "Photo condition analysis" in user_message
     assert "minor sole wear" in user_message
-
-
-def test_visual_condition_disagreement_penalizes_confidence_not_price():
-    item = Item(
-        id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-        seller_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
-        name="Nike Air Max 90",
-        category="Trainers",
-        condition=ItemCondition.like_new,
-        description="Like new trainers.",
-        visual_condition_report={
-            "condition_grade": "good",
-            "confidence": 0.9,
-            "photo_quality": "clear",
-        },
-        attributes={
-            "visual_condition": {
-                "seller_resolution": "seller_disagreed",
-                "seller_confirmed_condition": "like_new",
-                "vision_suggested_condition": "good",
-            }
-        },
-    )
-
-    adjusted, context = _apply_visual_condition_confidence_adjustment(item, 0.8)
-
-    assert adjusted == pytest.approx(0.8 * _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER)
-    assert context["visual_condition_confidence_penalty"] == pytest.approx(
-        _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
-    )
-
-
-@pytest.mark.parametrize(
-    "report, attrs",
-    [
-        ({"condition_grade": "good", "confidence": 0.5, "photo_quality": "clear"}, {}),
-        ({"condition_grade": "good", "confidence": 0.9, "photo_quality": "poor"}, {}),
-        (
-            {"condition_grade": "good", "confidence": 0.9, "photo_quality": "clear"},
-            {"visual_condition": {"seller_resolution": "accepted_vision"}},
-        ),
-    ],
-)
-def test_visual_condition_confidence_penalty_only_for_high_confidence_disagreement(
-    report, attrs
-):
-    item = Item(
-        id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
-        seller_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
-        name="Nike Air Max 90",
-        category="Trainers",
-        condition=ItemCondition.like_new,
-        description="Like new trainers.",
-        visual_condition_report=report,
-        attributes=attrs
-        or {
-            "visual_condition": {
-                "seller_resolution": "seller_disagreed",
-                "seller_confirmed_condition": "like_new",
-                "vision_suggested_condition": "good",
-            }
-        },
-    )
-
-    adjusted, context = _apply_visual_condition_confidence_adjustment(item, 0.8)
-
-    assert adjusted == pytest.approx(0.8)
-    assert context["visual_condition_confidence_penalty"] == pytest.approx(1.0)

--- a/tests/test_pricing_agent.py
+++ b/tests/test_pricing_agent.py
@@ -1,9 +1,17 @@
+import uuid
 from unittest.mock import patch
 
 import pytest
 
 from packages.agents.pricing import agent
-from packages.agents.pricing.agent import _blend_price
+from packages.agents.pricing.agent import (
+    _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER,
+    _apply_visual_condition_confidence_adjustment,
+    _blend_price,
+)
+from packages.agents.pricing.comparable_filter import validate_comparables
+from packages.db.models import Item, ItemCondition
+from packages.platform_adapters.ebay.browse import Comparable
 
 
 def test_get_sentence_model_missing_dependency_raises():
@@ -56,3 +64,120 @@ def test_blend_price_falls_back_to_a_single_available_signal():
     assert _blend_price(150.0, None, 3) == 150.0  # model unavailable
     assert _blend_price(None, 250.0, 3) == 250.0  # comparables unavailable
     assert _blend_price(None, None, 0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_validate_comparables_includes_visual_condition_context(monkeypatch):
+    captured = {}
+
+    class FakeCompletions:
+        async def create(self, **kwargs):
+            captured.update(kwargs)
+
+            class Msg:
+                content = '{"results":[{"index":1,"verdict":"keep"}]}'
+
+            class Choice:
+                message = Msg()
+
+            return type("Response", (), {"choices": [Choice()]})()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.chat = type("Chat", (), {"completions": FakeCompletions()})()
+
+    monkeypatch.setattr(
+        "packages.agents.pricing.comparable_filter.openai.AsyncOpenAI", FakeClient
+    )
+
+    comp = Comparable(
+        title="Nike Air Max 90 Used Good Condition",
+        price=45.0,
+        currency="GBP",
+        condition="Used",
+        item_id="123",
+        listing_url="https://example.com/123",
+    )
+
+    kept, rejected = await validate_comparables(
+        item_title="Nike Air Max 90",
+        item_category="Trainers",
+        item_brand="Nike",
+        item_description="Nike trainers.",
+        comparables=[comp],
+        visual_condition_context="visible defects: minor sole wear. avoid comps with: new, sealed",
+    )
+
+    assert kept == [comp]
+    assert rejected == []
+    user_message = captured["messages"][1]["content"]
+    assert "Photo condition analysis" in user_message
+    assert "minor sole wear" in user_message
+
+
+def test_visual_condition_disagreement_penalizes_confidence_not_price():
+    item = Item(
+        id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        seller_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.like_new,
+        description="Like new trainers.",
+        visual_condition_report={
+            "condition_grade": "good",
+            "confidence": 0.9,
+            "photo_quality": "clear",
+        },
+        attributes={
+            "visual_condition": {
+                "seller_resolution": "seller_disagreed",
+                "seller_confirmed_condition": "like_new",
+                "vision_suggested_condition": "good",
+            }
+        },
+    )
+
+    adjusted, context = _apply_visual_condition_confidence_adjustment(item, 0.8)
+
+    assert adjusted == pytest.approx(0.8 * _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER)
+    assert context["visual_condition_confidence_penalty"] == pytest.approx(
+        _VISION_DISAGREEMENT_CONFIDENCE_MULTIPLIER
+    )
+
+
+@pytest.mark.parametrize(
+    "report, attrs",
+    [
+        ({"condition_grade": "good", "confidence": 0.5, "photo_quality": "clear"}, {}),
+        ({"condition_grade": "good", "confidence": 0.9, "photo_quality": "poor"}, {}),
+        (
+            {"condition_grade": "good", "confidence": 0.9, "photo_quality": "clear"},
+            {"visual_condition": {"seller_resolution": "accepted_vision"}},
+        ),
+    ],
+)
+def test_visual_condition_confidence_penalty_only_for_high_confidence_disagreement(
+    report, attrs
+):
+    item = Item(
+        id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        seller_id=uuid.UUID("00000000-0000-0000-0000-000000000002"),
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.like_new,
+        description="Like new trainers.",
+        visual_condition_report=report,
+        attributes=attrs
+        or {
+            "visual_condition": {
+                "seller_resolution": "seller_disagreed",
+                "seller_confirmed_condition": "like_new",
+                "vision_suggested_condition": "good",
+            }
+        },
+    )
+
+    adjusted, context = _apply_visual_condition_confidence_adjustment(item, 0.8)
+
+    assert adjusted == pytest.approx(0.8)
+    assert context["visual_condition_confidence_penalty"] == pytest.approx(1.0)

--- a/tests/test_pricing_agent.py
+++ b/tests/test_pricing_agent.py
@@ -80,9 +80,7 @@ async def test_validate_comparables_includes_visual_condition_context(monkeypatc
         def __init__(self, **kwargs):
             self.chat = type("Chat", (), {"completions": FakeCompletions()})()
 
-    monkeypatch.setattr(
-        "packages.agents.pricing.comparable_filter.openai.AsyncOpenAI", FakeClient
-    )
+    monkeypatch.setattr("packages.agents.pricing.comparable_filter.openai.AsyncOpenAI", FakeClient)
 
     comp = Comparable(
         title="Nike Air Max 90 Used Good Condition",


### PR DESCRIPTION

Summary
Adds vision-assisted intake enrichment for uploaded item photos. Agent 1 can now use a vision model to improve thin or generic listings with visible descriptors, condition details, and defect notes, while keeping condition changes seller-confirmed. Agent 2 now accounts for seller/vision condition disagreement by reducing pricing confidence, without changing the recommended price.

Changes
Added intake vision analysis service for:
visible condition grading
visible defects
visual descriptors such as colour, style, shape, markings, accessories, and distinguishing features
listing description addendums
pricing/comparable search signals
Added analyze_images_for_descriptors intake tool for Agent 1.
Added item persistence for visual condition analysis:
visual_condition_report
visual_condition_analyzed_at
visual_condition_needs_confirmation
Added Alembic migration for the new item columns.
Updated intake flow so the final pre-completion guardrail runs vision when appropriate and skips duplicate analysis.
Tracks seller resolution when vision suggests a lower condition:
accepted_vision
seller_disagreed
Updated Agent 2 comparable filtering context with visual condition signals.
Applies a confidence-only penalty when the seller rejects high-confidence visual downgrade evidence.
Added config:
model_intake_vision
intake_vision_enabled