### PR TITLE
style: improve responsive design across pages with mobile-first layou…

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -66,7 +66,7 @@ function PricingPanel({ pricing }: { pricing: PricingResult }) {
 
         <ConfidenceBar score={pricing.confidence_score} />
 
-        <div className="flex justify-between text-sm">
+        <div className="flex flex-wrap justify-between gap-2 text-sm">
           <span className="text-muted-foreground">Walk-away floor</span>
           <span className="font-medium">{fmt(pricing.min_acceptable_price)}</span>
         </div>
@@ -148,7 +148,7 @@ function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
   return (
     <Card>
       <CardContent className="p-4 space-y-3">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm font-medium">{labels[listing.status] ?? listing.status}</p>
           <Badge variant={badgeVariant[listing.status] ?? "secondary"}>
             {listing.status}
@@ -363,15 +363,15 @@ function ChatPageInner() {
         connectingEbay={connectingEbay}
       >
         {/* Messages */}
-        <div className="flex flex-col h-screen">
-          <div className="flex-1 overflow-y-auto px-4 sm:px-6 py-6 space-y-4">
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-6 space-y-4">
             {messages.map((m, i) => (
               <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
-                <div className="max-w-lg space-y-2">
+                <div className="max-w-[min(32rem,88vw)] space-y-2 sm:max-w-lg">
                   {m.imageUrl && (
                     <div className="flex justify-end">
                       {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={m.imageUrl} alt="upload" className="max-h-48 rounded-xl border border-border object-cover" />
+                      <img src={m.imageUrl} alt="upload" className="max-h-48 max-w-full rounded-xl border border-border object-cover" />
                     </div>
                   )}
                   {m.content && (
@@ -404,12 +404,17 @@ function ChatPageInner() {
                 <div className="bg-card border border-border rounded-2xl rounded-bl-sm px-4 py-2.5 text-sm text-muted-foreground">…</div>
               </div>
             )}
+            {panel && (
+              <div className="xl:hidden pt-2">
+                {panel}
+              </div>
+            )}
             <div ref={bottomRef} />
           </div>
 
           <input ref={fileRef} type="file" accept="image/jpeg,image/png,image/gif,image/webp" multiple className="hidden" onChange={handleFileChange} />
 
-          <form onSubmit={sendMessage} className="border-t border-border bg-card px-4 sm:px-6 py-4 flex gap-3">
+          <form onSubmit={sendMessage} className="border-t border-border bg-card px-3 py-3 sm:px-6 sm:py-4 flex gap-2 sm:gap-3">
             <Input
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/apps/web/app/inbox/page.tsx
+++ b/apps/web/app/inbox/page.tsx
@@ -34,7 +34,7 @@ function DraftItem({ draft, onRemove }: { draft: DraftMessage; onRemove: (id: st
   return (
     <Card>
       <CardContent className="p-5 space-y-4">
-        <div className="flex justify-between items-center text-sm">
+        <div className="flex flex-wrap justify-between gap-2 text-sm">
           <span className="font-semibold">{draft.buyer_handle}</span>
           <span className="text-muted-foreground text-xs">{formatRelativeTime(draft.received_at)}</span>
         </div>
@@ -58,12 +58,13 @@ function DraftItem({ draft, onRemove }: { draft: DraftMessage; onRemove: (id: st
 
         {err && <p className="text-destructive text-xs">{err}</p>}
 
-        <div className="flex items-center gap-2 justify-end">
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
           <Button
             variant="ghost"
             size="sm"
             disabled={loading}
             onClick={() => act(() => api.dismissDraft(draft.message_id))}
+            className="w-full sm:w-auto"
           >
             Dismiss
           </Button>
@@ -72,6 +73,7 @@ function DraftItem({ draft, onRemove }: { draft: DraftMessage; onRemove: (id: st
               size="sm"
               disabled={loading || !text.trim()}
               onClick={() => act(() => api.editDraft(draft.message_id, text))}
+              className="w-full sm:w-auto"
             >
               Save &amp; Send
             </Button>
@@ -80,6 +82,7 @@ function DraftItem({ draft, onRemove }: { draft: DraftMessage; onRemove: (id: st
               size="sm"
               disabled={loading}
               onClick={() => act(() => api.approveDraft(draft.message_id))}
+              className="w-full sm:w-auto"
             >
               Approve
             </Button>
@@ -115,7 +118,7 @@ export default function InboxPage() {
 
   return (
     <AppShell inboxCount={drafts.length}>
-      <div className="px-4 sm:px-8 py-8">
+      <div className="px-4 py-6 sm:px-8 sm:py-8">
         <div className="max-w-2xl mx-auto space-y-6">
           <div className="pb-4 border-b border-border">
             <h1 className="text-xl font-semibold">Pending Approvals</h1>

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -51,7 +51,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center gap-4 px-4 bg-background">
+    <div className="min-h-dvh flex flex-col items-center justify-center gap-4 px-4 py-8 bg-background">
       <Card className="w-full max-w-sm">
         <CardHeader className="pb-2">
           <CardTitle className="text-center text-xl">SalesRep</CardTitle>

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -61,7 +61,7 @@ export default function OnboardingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background flex flex-col items-center justify-center px-4 py-12">
+    <div className="min-h-dvh bg-background flex flex-col items-center justify-center px-4 py-8 sm:py-12">
       <div className="w-full max-w-lg space-y-8">
         {/* Brand */}
         <div className="text-center">
@@ -121,6 +121,7 @@ export default function OnboardingPage() {
                   variant={ebayConnected ? "default" : "ghost"}
                   size="sm"
                   onClick={() => setStep(1)}
+                  className="w-full sm:w-auto"
                 >
                   {ebayConnected ? "Continue" : "Skip for now"}
                   <ChevronRight size={14} />
@@ -167,9 +168,9 @@ export default function OnboardingPage() {
                   <p className="text-xs text-muted-foreground mt-1 ml-7">{opt.description}</p>
                 </label>
               ))}
-              <div className="flex justify-between pt-2">
-                <Button variant="ghost" size="sm" onClick={() => setStep(0)}>Back</Button>
-                <Button size="sm" onClick={() => setStep(2)}>
+              <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-between">
+                <Button variant="ghost" size="sm" onClick={() => setStep(0)} className="w-full sm:w-auto">Back</Button>
+                <Button size="sm" onClick={() => setStep(2)} className="w-full sm:w-auto">
                   Continue <ChevronRight size={14} />
                 </Button>
               </div>
@@ -200,9 +201,9 @@ export default function OnboardingPage() {
                   Reply mode: <span className="font-medium text-foreground capitalize">{autonomy.replace(/_/g, " ")}</span>
                 </li>
               </ul>
-              <div className="flex justify-between pt-2">
-                <Button variant="ghost" size="sm" onClick={() => setStep(1)}>Back</Button>
-                <Button onClick={finishOnboarding} disabled={saving}>
+              <div className="flex flex-col-reverse gap-2 pt-2 sm:flex-row sm:justify-between">
+                <Button variant="ghost" size="sm" onClick={() => setStep(1)} className="w-full sm:w-auto">Back</Button>
+                <Button onClick={finishOnboarding} disabled={saving} className="w-full sm:w-auto">
                   {saving ? "Saving…" : "Go to chat"}
                 </Button>
               </div>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -68,7 +68,7 @@ function BillingCard({ billing }: { billing: BillingStatus }) {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <CardTitle>Subscription</CardTitle>
           <Badge variant={isPro && isActive ? "success" : "secondary"}>
             {isPro ? "Pro" : "Free"}
@@ -168,7 +168,7 @@ export default function SettingsPage() {
 
   return (
     <AppShell>
-      <div className="px-4 sm:px-8 py-8">
+      <div className="px-4 py-6 sm:px-8 sm:py-8">
         <div className="max-w-3xl mx-auto space-y-8">
           <header className="pb-4 border-b border-border">
             <h1 className="text-xl font-semibold">Settings</h1>
@@ -262,13 +262,13 @@ export default function SettingsPage() {
               </Card>
 
               {/* Save */}
-              <div className="flex items-center justify-end gap-4">
+              <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
                 {saveMsg && (
                   <span className={`text-sm ${saveMsg === "Saved" ? "text-emerald-600" : "text-destructive"}`}>
                     {saveMsg}
                   </span>
                 )}
-                <Button onClick={handleSave} disabled={saving}>
+                <Button onClick={handleSave} disabled={saving} className="w-full sm:w-auto">
                   {saving ? "Saving…" : "Save settings"}
                 </Button>
               </div>
@@ -305,8 +305,8 @@ export default function SettingsPage() {
                   ) : (
                     <ul className="divide-y divide-border">
                       {reprices.map((r) => (
-                        <li key={r.id} className="py-3 flex items-center justify-between text-sm">
-                          <div className="min-w-0 flex-1 mr-4">
+                        <li key={r.id} className="py-3 flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
+                          <div className="min-w-0 flex-1">
                             <p className="font-medium truncate">
                               {r.listing_url ? (
                                 <a href={r.listing_url} target="_blank" rel="noreferrer" className="hover:underline">
@@ -316,7 +316,7 @@ export default function SettingsPage() {
                             </p>
                             <p className="text-xs text-muted-foreground">{formatDate(r.repriced_at)}</p>
                           </div>
-                          <div className="text-right shrink-0">
+                          <div className="shrink-0 sm:text-right">
                             <span className="text-muted-foreground line-through mr-2">{formatGBP(r.old_price)}</span>
                             <span className="font-semibold">{formatGBP(r.new_price)}</span>
                           </div>

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -23,6 +23,10 @@ const NAV_ITEMS = [
   { href: "/settings", label: "Settings", Icon: Settings },
 ];
 
+function currentTitle(pathname: string) {
+  return NAV_ITEMS.find((item) => pathname === item.href || pathname.startsWith(item.href + "/"))?.label ?? "SalesRep";
+}
+
 export function AppShell({
   children,
   panel,
@@ -115,7 +119,7 @@ export function AppShell({
   );
 
   return (
-    <div className="flex h-screen bg-background overflow-hidden">
+    <div className="flex h-dvh bg-background overflow-hidden">
       {/* Mobile overlay */}
       {mobileOpen && (
         <div
@@ -136,26 +140,31 @@ export function AppShell({
       </aside>
 
       {/* Main area */}
-      <div className="flex flex-1 min-w-0 overflow-hidden">
-        {/* Mobile hamburger */}
-        <button
-          className="absolute top-3 left-3 z-10 lg:hidden text-muted-foreground hover:text-foreground p-1"
-          onClick={() => setMobileOpen(true)}
-        >
-          <Menu size={20} />
-        </button>
+      <div className="flex flex-1 min-w-0 flex-col overflow-hidden">
+        <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border bg-card px-4 lg:hidden">
+          <button
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open navigation"
+          >
+            <Menu size={20} />
+          </button>
+          <p className="text-sm font-semibold">{currentTitle(pathname)}</p>
+        </header>
 
-        {/* Content */}
-        <main className="flex-1 min-w-0 overflow-y-auto">
-          {children}
-        </main>
+        <div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
+          {/* Content */}
+          <main className="flex-1 min-w-0 overflow-y-auto">
+            {children}
+          </main>
 
-        {/* Optional right panel */}
-        {panel && (
-          <aside className="w-80 shrink-0 bg-background border-l border-border p-5 overflow-y-auto hidden xl:block">
-            {panel}
-          </aside>
-        )}
+          {/* Optional right panel */}
+          {panel && (
+            <aside className="w-80 shrink-0 bg-background border-l border-border p-5 overflow-y-auto hidden xl:block">
+              {panel}
+            </aside>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Added a mobile top bar to the shared app shell with accessible navigation drawer controls.
- Switched authenticated app layout sizing to `h-dvh` so mobile browser chrome is handled more reliably.
- Made chat mobile-friendly by keeping pricing/listing panels visible inline on small screens and constraining message/image widths.
- Improved mobile wrapping and full-width actions across inbox drafts, settings, login, and onboarding screens.


