### PR TITLE
feat: implement ECR-based production deployment pipeline with docker-…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 # Requires the CodeBuild project to have:
 #   - Environment: LINUX_EC2 (Docker works natively, no privileged mode needed)
-#   - Environment variables: AWS_REGION, EC2_INSTANCE_ID
+#   - Environment variables: AWS_REGION, EC2_INSTANCE_ID, ECR_REPOSITORY_URI
 #   - (Optional) S3 cache bucket configured to use the cache section below
 
 phases:
@@ -13,11 +13,26 @@ phases:
     commands:
       - pip install uv --quiet
       - uv sync --extra dev --no-group dev
-      - npm --prefix apps/web install
+      - npm --prefix apps/web ci
 
   pre_build:
     on-failure: ABORT
     commands:
+      - |
+        set -e
+        BRANCH="${CODEBUILD_WEBHOOK_HEAD_REF:-}"
+        if [ -z "$BRANCH" ]; then
+          case "${CODEBUILD_WEBHOOK_TRIGGER:-}" in
+            branch/main) BRANCH="refs/heads/main" ;;
+          esac
+        fi
+        if [ -z "$BRANCH" ]; then
+          case "${CODEBUILD_SOURCE_VERSION:-}" in
+            main|refs/heads/main) BRANCH="refs/heads/main" ;;
+          esac
+        fi
+        echo "Branch is '${BRANCH:-unknown}'"
+        echo "export CI_BRANCH='$BRANCH'" > /tmp/ci-env
       # Lint & format
       - uv run ruff check .
       - uv run ruff format --check .
@@ -25,10 +40,15 @@ phases:
       - uv run mypy apps packages workers
       # Tests (all mock-based, no live DB needed)
       - JWT_SECRET_KEY=ci-test-secret uv run pytest tests/ --ignore=tests/evals/ --cov
-      # Run LangSmith Evaluations
-      - uv run pytest tests/evals/
-      # Validate Dockerfile builds (requires privileged mode)
-      - docker build .
+      # Run LangSmith evaluations only on main, before deployment.
+      - |
+        set -e
+        . /tmp/ci-env
+        if [ "$CI_BRANCH" = "refs/heads/main" ]; then
+          uv run pytest tests/evals/
+        else
+          echo "Skipping LangSmith evaluations on non-main branch"
+        fi
       # Frontend type check + build
       - npm --prefix apps/web run build
 
@@ -40,17 +60,37 @@ phases:
       # exit from one block does NOT skip the next.
       - |
         set -e
+        . /tmp/ci-env
 
         # Only deploy when merging/pushing to main.
-        BRANCH="${CODEBUILD_WEBHOOK_HEAD_REF:-}"
-        if [ "$BRANCH" != "refs/heads/main" ]; then
-          echo "Branch is '$BRANCH' — skipping deploy (main only)"
+        if [ "$CI_BRANCH" != "refs/heads/main" ]; then
+          echo "Branch is '$CI_BRANCH' — skipping image build and deploy (main only)"
           exit 0
         fi
 
+        : "${AWS_REGION:?AWS_REGION is required}"
+        : "${EC2_INSTANCE_ID:?EC2_INSTANCE_ID is required}"
+        : "${ECR_REPOSITORY_URI:?ECR_REPOSITORY_URI is required}"
+
+        IMAGE_TAG="${CODEBUILD_RESOLVED_SOURCE_VERSION:-latest}"
+        API_IMAGE="$ECR_REPOSITORY_URI:$IMAGE_TAG"
+        CACHE_IMAGE="$ECR_REPOSITORY_URI:buildcache"
+        ECR_REGISTRY="${ECR_REPOSITORY_URI%/*}"
+
+        aws ecr get-login-password --region "$AWS_REGION" \
+          | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+        docker buildx create --use --name salesrep-builder 2>/dev/null || docker buildx use salesrep-builder
+        docker buildx build \
+          --cache-from "type=registry,ref=$CACHE_IMAGE" \
+          --cache-to "type=registry,ref=$CACHE_IMAGE,mode=max" \
+          --tag "$API_IMAGE" \
+          --push \
+          .
+
         CMD_ID=$(aws ssm send-command \
-          --region $AWS_REGION \
-          --instance-ids $EC2_INSTANCE_ID \
+          --region "$AWS_REGION" \
+          --instance-ids "$EC2_INSTANCE_ID" \
           --document-name "AWS-RunShellScript" \
           --parameters '{"commands":[
             "set -e",
@@ -59,10 +99,13 @@ phases:
             "cd /home/ubuntu/multi-agentic-sales-representative-system",
             "git fetch origin",
             "git reset --hard origin/main",
+            "export API_IMAGE='"$API_IMAGE"'",
+            "export ECR_REGISTRY='"$ECR_REGISTRY"'",
             "sudo docker container prune -f",
-            "sudo docker compose build api sqs-worker",
-            "sudo docker compose run --rm api uv run alembic upgrade head",
-            "sudo docker compose up -d"
+            "aws ecr get-login-password --region '"$AWS_REGION"' | sudo docker login --username AWS --password-stdin $ECR_REGISTRY",
+            "sudo -E docker compose -f docker-compose.prod.yml --profile worker pull api sqs-worker",
+            "sudo -E docker compose -f docker-compose.prod.yml run --rm api uv run alembic upgrade head",
+            "sudo -E docker compose -f docker-compose.prod.yml --profile worker up -d"
           ]}' \
           --output text \
           --query "Command.CommandId")
@@ -72,24 +115,24 @@ phases:
         # pre-bakes HF models, so the first uncached build can take 10+ min.
         for i in $(seq 1 120); do
           STATUS=$(aws ssm get-command-invocation \
-            --region $AWS_REGION \
-            --command-id $CMD_ID \
-            --instance-id $EC2_INSTANCE_ID \
+            --region "$AWS_REGION" \
+            --command-id "$CMD_ID" \
+            --instance-id "$EC2_INSTANCE_ID" \
             --query "Status" --output text 2>/dev/null || echo "Pending")
           echo "[$i/120] $STATUS"
           if [ "$STATUS" = "Success" ]; then exit 0; fi
           if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ]; then
             echo "=== STDOUT ==="
             aws ssm get-command-invocation \
-              --region $AWS_REGION \
-              --command-id $CMD_ID \
-              --instance-id $EC2_INSTANCE_ID \
+              --region "$AWS_REGION" \
+              --command-id "$CMD_ID" \
+              --instance-id "$EC2_INSTANCE_ID" \
               --query "StandardOutputContent" --output text
             echo "=== STDERR ==="
             aws ssm get-command-invocation \
-              --region $AWS_REGION \
-              --command-id $CMD_ID \
-              --instance-id $EC2_INSTANCE_ID \
+              --region "$AWS_REGION" \
+              --command-id "$CMD_ID" \
+              --instance-id "$EC2_INSTANCE_ID" \
               --query "StandardErrorContent" --output text
             exit 1
           fi
@@ -102,5 +145,6 @@ cache:
   paths:
     - "/root/.cache/uv/**/*"
     - "/root/.cache/mypy/**/*"
+    - "/root/.npm/**/*"
     - "apps/web/node_modules/**/*"
     - "apps/web/.next/cache/**/*"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,66 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-salesrep}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-salesrep}
+      POSTGRES_DB: ${POSTGRES_DB:-salesrep}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    image: ${API_IMAGE}
+    env_file: .env
+    command: uvicorn apps.api.main:app --host 0.0.0.0 --port 8000
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-salesrep}:${POSTGRES_PASSWORD:-salesrep}@postgres:5432/${POSTGRES_DB:-salesrep}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL-}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY-}
+      S3_SECRET_KEY: ${S3_SECRET_KEY-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-change-me-in-production}
+      TOKEN_ENCRYPTION_KEY: ${TOKEN_ENCRYPTION_KEY:-}
+      SQS_QUEUE_URL: ${SQS_QUEUE_URL:-}
+      SQS_REGION: ${SQS_REGION:-us-east-1}
+      INTERNAL_API_KEY: ${INTERNAL_API_KEY:-}
+      LANGSMITH_TRACING: ${LANGSMITH_TRACING:-false}
+      LANGSMITH_API_KEY: ${LANGSMITH_API_KEY:-}
+      LANGSMITH_PROJECT: ${LANGSMITH_PROJECT:-salesrep}
+    ports:
+      - "8000:8000"
+    volumes:
+      - hf_cache:/opt/hf-cache
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  sqs-worker:
+    profiles: ["worker"]
+    image: ${API_IMAGE}
+    env_file: .env
+    command: uv run python -m workers.sqs_worker
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-salesrep}:${POSTGRES_PASSWORD:-salesrep}@postgres:5432/${POSTGRES_DB:-salesrep}
+      SQS_QUEUE_URL: ${SQS_QUEUE_URL:-}
+      SQS_REGION: ${SQS_REGION:-us-east-1}
+      AWS_REGION: ${AWS_REGION:-eu-west-2}
+      LANGSMITH_TRACING: ${LANGSMITH_TRACING:-false}
+      LANGSMITH_API_KEY: ${LANGSMITH_API_KEY:-}
+      LANGSMITH_PROJECT: ${LANGSMITH_PROJECT:-salesrep}
+    volumes:
+      - hf_cache:/opt/hf-cache
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+  hf_cache:


### PR DESCRIPTION
## Summary

Improves CI/CD efficiency by building the backend Docker image once in CodeBuild, pushing it to ECR, and deploying that immutable image to EC2 instead of rebuilding on the host.

## Changes

- Replaced `npm install` with `npm ci` for deterministic frontend installs.
- Added branch detection so non-`main` builds skip deploy image work.
- Kept LangSmith evals in CI, but limited them to `main` only.
- Added BuildKit registry cache support for Docker builds via ECR.
- Changed deployment flow to:
  - build and push image in CodeBuild
  - SSM into EC2
  - log into ECR
  - pull the pushed image
  - run migrations
  - restart services
- Added `docker-compose.prod.yml` for production image-based deploys without dev bind mounts or `--reload`.

## Notes

This does not add any scheduled or routine evaluation system.

## Required Infra Updates

- Add `ECR_REPOSITORY_URI` to the CodeBuild environment.
- Ensure the CodeBuild IAM role can push to ECR.
- Ensure the EC2 instance role can pull from ECR.

## Validation

- Parsed `buildspec.yml` and `docker-compose.prod.yml` as valid YAML.
- Ran `docker compose -f docker-compose.prod.yml config`.
- Ran `git diff --check`.
