### PR TITLE
feat: add listing approval gate and UI workflow for manual publishing…

### DIFF
--- a/alembic/versions/0015_listing_approval_gate.py
+++ b/alembic/versions/0015_listing_approval_gate.py
@@ -1,0 +1,59 @@
+"""listing approval gate
+
+Adds a default-on seller setting that pauses newly priced listings for
+seller approval, plus a listing status that the chat UI can poll.
+
+Revision ID: 0015_listing_approval
+Revises: 0014_phase7a
+Create Date: 2026-05-16
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0015_listing_approval"
+down_revision: str | None = "0014_phase7a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TYPE listing_status ADD VALUE IF NOT EXISTS 'pending_approval' BEFORE 'publishing'"
+    )
+    op.add_column(
+        "sellers",
+        sa.Column(
+            "require_listing_approval",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sellers", "require_listing_approval")
+    # PostgreSQL cannot drop enum values directly. Rebuild the enum only if
+    # no rows still use the approval status.
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM listings WHERE status = 'pending_approval') THEN
+                RAISE EXCEPTION 'Cannot downgrade while listings are pending approval';
+            END IF;
+        END $$;
+    """)
+    op.execute("ALTER TYPE listing_status RENAME TO listing_status_old")
+    op.execute("CREATE TYPE listing_status AS ENUM ('publishing', 'live', 'ended', 'error')")
+    op.execute("ALTER TABLE listings ALTER COLUMN status DROP DEFAULT")
+    op.execute("""
+        ALTER TABLE listings
+        ALTER COLUMN status TYPE listing_status
+        USING status::text::listing_status
+    """)
+    op.execute("ALTER TABLE listings ALTER COLUMN status SET DEFAULT 'publishing'::listing_status")
+    op.execute("DROP TYPE listing_status_old")

--- a/apps/api/routers/intake.py
+++ b/apps/api/routers/intake.py
@@ -8,14 +8,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from apps.api.deps import get_current_seller
 from packages.agents.intake.agent import load_history
 from packages.agents.intake.agent import run as run_agent
-from packages.agents.pipeline import run_pipeline
+from packages.agents.pipeline import run_pipeline, run_publisher_only
 from packages.config import settings
 from packages.db.models import (
     ChatMessage,
     ChatRole,
     ClarificationRequest,
     Item,
+    ItemStatus,
     Listing,
+    ListingStatus,
     Platform,
     Seller,
 )
@@ -221,3 +223,59 @@ async def get_listing_status(
         "external_id": listing.external_id,
         "posted_price": float(listing.posted_price) if listing.posted_price else None,
     }
+
+
+@router.post("/listing/{item_id}/approve")
+async def approve_listing(
+    item_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+    seller: Seller = Depends(get_current_seller),
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, str]:
+    """Approve a priced listing and resume publishing to eBay."""
+    item = await session.scalar(select(Item).where(Item.id == item_id, Item.seller_id == seller.id))
+    if item is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+    if item.recommended_price is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Listing is not priced yet"
+        )
+
+    listing = await session.scalar(
+        select(Listing).where(
+            Listing.item_id == item_id,
+            Listing.seller_id == seller.id,
+            Listing.platform == Platform.ebay,
+        )
+    )
+    if listing is None:
+        listing = Listing(
+            item_id=item_id,
+            seller_id=seller.id,
+            platform=Platform.ebay,
+            status=ListingStatus.publishing,
+            posted_price=item.recommended_price,
+        )
+        session.add(listing)
+    elif listing.status == ListingStatus.live:
+        return {"status": ListingStatus.live.value}
+    elif listing.status not in {ListingStatus.pending_approval, ListingStatus.error}:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Listing is already {listing.status}",
+        )
+
+    listing.status = ListingStatus.publishing
+    listing.close_reason = None
+    listing.posted_price = item.recommended_price
+    item.status = ItemStatus.publishing
+    await session.commit()
+
+    if settings.sqs_queue_url:
+        from packages.bus.sqs import enqueue
+
+        enqueue("publish_only", seller_id=str(seller.id), item_id=str(item_id))
+    else:
+        background_tasks.add_task(run_publisher_only, seller.id, item_id)
+
+    return {"status": ListingStatus.publishing.value}

--- a/apps/api/routers/settings.py
+++ b/apps/api/routers/settings.py
@@ -16,7 +16,12 @@ from apps.api.deps import get_current_seller
 from packages.db.models import AutonomyLevel, Seller
 from packages.db.session import get_session
 
-_DEMO_WRITE_FIELDS = {"autonomy_level", "stale_threshold_days", "max_reprice_count"}
+_DEMO_WRITE_FIELDS = {
+    "autonomy_level",
+    "stale_threshold_days",
+    "max_reprice_count",
+    "require_listing_approval",
+}
 
 # get_current_seller and get_session may return objects from different
 # SQLAlchemy sessions when dependencies are overridden in tests. In production
@@ -38,12 +43,14 @@ class SellerSettings(BaseModel):
     autonomy_level: AutonomyLevel
     stale_threshold_days: int = Field(ge=_MIN_STALE_DAYS, le=_MAX_STALE_DAYS)
     max_reprice_count: int = Field(ge=_MIN_REPRICE, le=_MAX_REPRICE)
+    require_listing_approval: bool
 
 
 class SellerSettingsPatch(BaseModel):
     autonomy_level: AutonomyLevel | None = None
     stale_threshold_days: int | None = Field(default=None, ge=_MIN_STALE_DAYS, le=_MAX_STALE_DAYS)
     max_reprice_count: int | None = Field(default=None, ge=_MIN_REPRICE, le=_MAX_REPRICE)
+    require_listing_approval: bool | None = None
 
 
 def _serialise(seller: Seller) -> dict[str, Any]:
@@ -51,6 +58,7 @@ def _serialise(seller: Seller) -> dict[str, Any]:
         "autonomy_level": seller.autonomy_level.value,
         "stale_threshold_days": seller.stale_threshold_days,
         "max_reprice_count": seller.max_reprice_count,
+        "require_listing_approval": seller.require_listing_approval,
     }
 
 
@@ -71,6 +79,7 @@ async def update_seller_settings(
         body.autonomy_level is None
         and body.stale_threshold_days is None
         and body.max_reprice_count is None
+        and body.require_listing_approval is None
     ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -88,6 +97,8 @@ async def update_seller_settings(
         db_seller.stale_threshold_days = body.stale_threshold_days
     if body.max_reprice_count is not None:
         db_seller.max_reprice_count = body.max_reprice_count
+    if body.require_listing_approval is not None:
+        db_seller.require_listing_approval = body.require_listing_approval
 
     await session.commit()
     await session.refresh(db_seller)

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useRef, useState, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Camera, Send } from "lucide-react";
+import { Camera, CheckCircle2, Send, X } from "lucide-react";
 import { api, PricingResult, ListingStatus } from "@/lib/api";
 import { AppShell } from "@/components/AppShell";
 import { Toast, ToastType } from "@/components/Toast";
@@ -127,8 +127,15 @@ function PricingPanelSkeleton() {
 
 /* ── Listing status panel ───────────────────────────────────────────── */
 
-function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
+function ListingStatusPanel({
+  listing,
+  onReview,
+}: {
+  listing: ListingStatus;
+  onReview: () => void;
+}) {
   const badgeVariant: Record<string, "success" | "warning" | "destructive" | "info" | "secondary"> = {
+    pending_approval: "warning",
     live: "success",
     publishing: "warning",
     error: "destructive",
@@ -136,6 +143,7 @@ function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
     ended: "secondary",
   };
   const labels: Record<string, string> = {
+    pending_approval: "Ready for approval",
     live: "Live on eBay",
     publishing: "Publishing…",
     error: "Publish failed",
@@ -144,9 +152,22 @@ function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
       : "More info needed",
     ended: "Listing ended",
   };
+  const isPendingApproval = listing.status === "pending_approval";
 
   return (
-    <Card>
+    <Card
+      role={isPendingApproval ? "button" : undefined}
+      tabIndex={isPendingApproval ? 0 : undefined}
+      onClick={isPendingApproval ? onReview : undefined}
+      onKeyDown={(e) => {
+        if (!isPendingApproval) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onReview();
+        }
+      }}
+      className={isPendingApproval ? "cursor-pointer transition-colors hover:bg-accent/40" : undefined}
+    >
       <CardContent className="p-4 space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-sm font-medium">{labels[listing.status] ?? listing.status}</p>
@@ -158,6 +179,9 @@ function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
           <p className="text-xs text-muted-foreground">
             Listed at <span className="font-medium text-foreground">{fmt(listing.posted_price)}</span>
           </p>
+        )}
+        {isPendingApproval && (
+          <p className="text-xs text-muted-foreground">Click to review before publishing</p>
         )}
         {listing.url && (
           <a
@@ -171,6 +195,71 @@ function ListingStatusPanel({ listing }: { listing: ListingStatus }) {
         )}
       </CardContent>
     </Card>
+  );
+}
+
+function ListingApprovalPrompt({
+  listing,
+  pricing,
+  approving,
+  onApprove,
+  onClose,
+}: {
+  listing: ListingStatus;
+  pricing: PricingResult | null;
+  approving: boolean;
+  onApprove: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 backdrop-blur-sm">
+      <Card className="w-full max-w-md">
+        <CardContent className="p-5 space-y-5">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-base font-semibold">Review listing</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                This listing is ready to go live on eBay.
+              </p>
+            </div>
+            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close review">
+              <X size={16} />
+            </Button>
+          </div>
+
+          <div className="space-y-2 rounded-xl border border-border bg-muted/40 p-3 text-sm">
+            <div className="flex justify-between gap-3">
+              <span className="text-muted-foreground">Recommended price</span>
+              <span className="font-medium">
+                {pricing ? fmt(pricing.recommended_price) : listing.posted_price != null ? fmt(listing.posted_price) : "Pending"}
+              </span>
+            </div>
+            {pricing && pricing.price_low > 0 && pricing.price_high > 0 && (
+              <div className="flex justify-between gap-3">
+                <span className="text-muted-foreground">Price range</span>
+                <span className="font-medium">{fmt(pricing.price_low)} - {fmt(pricing.price_high)}</span>
+              </div>
+            )}
+            {pricing && (
+              <div className="flex justify-between gap-3">
+                <span className="text-muted-foreground">Walk-away floor</span>
+                <span className="font-medium">{fmt(pricing.min_acceptable_price)}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button variant="outline" onClick={onClose} disabled={approving}>
+              Keep as draft
+            </Button>
+            <Button onClick={onApprove} disabled={approving}>
+              <CheckCircle2 size={15} />
+              {approving ? "Publishing…" : "Approve & publish"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 
@@ -191,6 +280,8 @@ function ChatPageInner() {
   const [pricingPending, setPricingPending] = useState(false);
   const [listingStatus, setListingStatus] = useState<ListingStatus | null>(null);
   const [listingPending, setListingPending] = useState(false);
+  const [approvalOpen, setApprovalOpen] = useState(false);
+  const [approvingListing, setApprovingListing] = useState(false);
 
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollAttempts = useRef(0);
@@ -221,10 +312,10 @@ function ChatPageInner() {
   useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages]);
   useEffect(() => () => { if (pollRef.current) clearInterval(pollRef.current); }, []);
 
-  const startPolling = useCallback((id: string) => {
+  const startPolling = useCallback((id: string, pollPricing = true) => {
     if (pollRef.current) clearInterval(pollRef.current);
     pollAttempts.current = 0;
-    setPricingPending(true);
+    if (pollPricing) setPricingPending(true);
 
     pollRef.current = setInterval(async () => {
       pollAttempts.current++;
@@ -235,7 +326,7 @@ function ChatPageInner() {
         return;
       }
       try {
-        if (!pricingResult) {
+        if (pollPricing && !pricingResult) {
           const result = await api.getPricing(id);
           if (result) {
             setPricingPending(false);
@@ -257,7 +348,7 @@ function ChatPageInner() {
               );
             }
           }
-          if (["live","error","ended","needs_specifics"].includes(ls.status)) {
+          if (["pending_approval","live","error","ended","needs_specifics"].includes(ls.status)) {
             setListingPending(false);
             if (!pricingPending) clearInterval(pollRef.current!);
           }
@@ -329,6 +420,23 @@ function ChatPageInner() {
     }
   }
 
+  async function approveListing() {
+    if (!itemId || approvingListing) return;
+    setApprovingListing(true);
+    try {
+      await api.approveListing(itemId);
+      setApprovalOpen(false);
+      setListingStatus((prev) => prev ? { ...prev, status: "publishing" } : prev);
+      setListingPending(true);
+      startPolling(itemId, false);
+      setToast({ message: "Listing approved. Publishing to eBay…", type: "success" });
+    } catch (err) {
+      setToast({ message: err instanceof Error ? err.message : "Approval failed", type: "error" });
+    } finally {
+      setApprovingListing(false);
+    }
+  }
+
   const showPricingPanel = pricingResult !== null || pricingPending;
   const showListingPanel = listingStatus !== null || listingPending;
 
@@ -347,7 +455,12 @@ function ChatPageInner() {
           {listingPending && !listingStatus ? (
             <Card><CardContent className="p-4"><Skeleton className="h-4 w-40" /></CardContent></Card>
           ) : null}
-          {listingStatus ? <ListingStatusPanel listing={listingStatus} /> : null}
+          {listingStatus ? (
+            <ListingStatusPanel
+              listing={listingStatus}
+              onReview={() => setApprovalOpen(true)}
+            />
+          ) : null}
         </div>
       )}
     </div>
@@ -356,6 +469,15 @@ function ChatPageInner() {
   return (
     <>
       {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}
+      {approvalOpen && listingStatus?.status === "pending_approval" && (
+        <ListingApprovalPrompt
+          listing={listingStatus}
+          pricing={pricingResult}
+          approving={approvingListing}
+          onApprove={approveListing}
+          onClose={() => setApprovalOpen(false)}
+        />
+      )}
       <AppShell
         panel={panel}
         ebayConnected={ebayConnected}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -225,6 +225,34 @@ export default function SettingsPage() {
                 </CardContent>
               </Card>
 
+              {/* Listing approval */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>Listing approval</CardTitle>
+                  <CardDescription>
+                    Review priced listings before they go live on eBay.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-border px-4 py-3 transition-colors hover:bg-accent/40">
+                    <input
+                      type="checkbox"
+                      checked={settings.require_listing_approval}
+                      onChange={(e) => update({ require_listing_approval: e.target.checked })}
+                      className="mt-0.5 accent-primary"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium">
+                        Require approval before publishing listings
+                      </span>
+                      <span className="mt-1 block text-xs text-muted-foreground">
+                        When enabled, priced listings pause in chat until you approve them.
+                      </span>
+                    </span>
+                  </label>
+                </CardContent>
+              </Card>
+
               {/* Reprice */}
               <Card>
                 <CardHeader>

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -75,7 +75,7 @@ export interface EbayStatusResponse {
 }
 
 export interface ListingStatus {
-  status: "publishing" | "live" | "ended" | "error" | "needs_specifics";
+  status: "pending_approval" | "publishing" | "live" | "ended" | "error" | "needs_specifics";
   url: string | null;
   external_id: string | null;
   posted_price: number | null;
@@ -98,6 +98,7 @@ export interface SellerSettings {
   autonomy_level: AutonomyLevel;
   stale_threshold_days: number;
   max_reprice_count: number;
+  require_listing_approval: boolean;
 }
 
 export interface RepriceEvent {
@@ -170,6 +171,11 @@ export const api = {
   // Returns null while listing is not yet created, ListingStatus once publisher runs
   getListingStatus: (itemId: string) =>
     request<ListingStatus | null>(`/agent/intake/listing/${itemId}`),
+
+  approveListing: (itemId: string) =>
+    request<{ status: string }>(`/agent/intake/listing/${itemId}/approve`, {
+      method: "POST",
+    }),
 
   getDrafts: () =>
     request<DraftMessage[]>("/conversations/drafts"),

--- a/packages/agents/pipeline.py
+++ b/packages/agents/pipeline.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 
 from packages.agents.pricing.agent import run as run_pricing
 from packages.agents.publisher.agent import run as run_publisher
-from packages.db.models import Item, ItemStatus
+from packages.db.models import Item, ItemStatus, Listing, ListingStatus, Platform, Seller
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +89,35 @@ async def publisher_node(state: PipelineState, config: RunnableConfig) -> dict[s
 
     # Load the item to get the persisted min_acceptable_price
     item = await session.scalar(select(Item).where(Item.id == item_id, Item.seller_id == seller_id))
+    seller = await session.get(Seller, seller_id)
+    if item is None or seller is None:
+        return {"error": "Item or seller not found"}
+
+    existing_listing = await session.scalar(
+        select(Listing).where(
+            Listing.item_id == item_id,
+            Listing.seller_id == seller_id,
+            Listing.platform == Platform.ebay,
+        )
+    )
+
+    if seller.require_listing_approval and (
+        existing_listing is None
+        or existing_listing.status in {ListingStatus.pending_approval, ListingStatus.error}
+    ):
+        listing = existing_listing or Listing(
+            item_id=item_id,
+            seller_id=seller_id,
+            platform=Platform.ebay,
+        )
+        listing.status = ListingStatus.pending_approval
+        listing.posted_price = state.recommended_price
+        listing.close_reason = None
+        if existing_listing is None:
+            session.add(listing)
+        await session.commit()
+        return {"listing_status": ListingStatus.pending_approval.value, "listing_url": None}
+
     min_price = float(item.min_acceptable_price) if item and item.min_acceptable_price else 0.0
 
     pricing = PricingResult(

--- a/packages/db/models.py
+++ b/packages/db/models.py
@@ -62,6 +62,7 @@ class Platform(enum.StrEnum):
 
 class ListingStatus(enum.StrEnum):
     # Listing lifecycle through publishing → sale
+    pending_approval = "pending_approval"  # Priced and waiting for seller approval
     publishing = "publishing"  # Being pushed to marketplace
     live = "live"  # Visible and active on marketplace
     ended = "ended"  # Closed (sold, withdrawn, etc.)
@@ -139,6 +140,8 @@ class Seller(Base):
     stale_threshold_days: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
     # Hard cap on automatic reprices per listing
     max_reprice_count: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    # Default-on approval gate before a priced item is published to eBay
+    require_listing_approval: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
     # Onboarding + demo flags (Phase 7)
     onboarding_completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/tests/test_settings_router.py
+++ b/tests/test_settings_router.py
@@ -51,6 +51,7 @@ async def test_get_settings_returns_defaults():
         assert body["autonomy_level"] == "draft"
         assert body["stale_threshold_days"] == 7
         assert body["max_reprice_count"] == 3
+        assert body["require_listing_approval"] is True
 
 
 @pytest.mark.asyncio
@@ -74,6 +75,7 @@ async def test_patch_settings_updates_fields():
                         "autonomy_level": "auto_low_risk",
                         "stale_threshold_days": 14,
                         "max_reprice_count": 5,
+                        "require_listing_approval": False,
                     },
                 )
         finally:
@@ -84,11 +86,13 @@ async def test_patch_settings_updates_fields():
         assert body["autonomy_level"] == "auto_low_risk"
         assert body["stale_threshold_days"] == 14
         assert body["max_reprice_count"] == 5
+        assert body["require_listing_approval"] is False
 
         await session.refresh(seller)
         assert seller.autonomy_level == AutonomyLevel.auto_low_risk
         assert seller.stale_threshold_days == 14
         assert seller.max_reprice_count == 5
+        assert seller.require_listing_approval is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a default-on seller approval gate before newly priced listings are published to eBay.

## Changes

- Added `require_listing_approval` seller setting, defaulting to `true`
- Added `pending_approval` listing status via Alembic migration
- Updated the pricing → publishing pipeline to pause after pricing when listing approval is enabled
- Added `POST /agent/intake/listing/{item_id}/approve` to resume publishing
- Added a clickable pending listing card in chat that opens an approval prompt
- Added a settings checkbox to turn listing approval on or off
- Updated frontend API types and settings tests for the new field

## Verification

- `uv run ruff check apps/api/routers/intake.py apps/api/routers/settings.py packages/agents/pipeline.py packages/db/models.py tests/test_settings_router.py`
- `npm run build`
- `uv run pytest tests/test_publisher.py -q`

Note: `uv run pytest tests/test_settings_router.py -q` was skipped locally because Postgres was not reachable.
