### PR TITLE
feat: auto-run vision analysis at intake completion

### DIFF
--- a/packages/agents/intake/graph.py
+++ b/packages/agents/intake/graph.py
@@ -18,6 +18,7 @@ Graph structure (ReAct loop):
 import json
 import logging
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
 import openai
@@ -29,6 +30,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from packages.agents.intake import vision
 from packages.agents.intake.tools import (
     CATEGORY_ENRICHMENT_HINTS,
     CATEGORY_LIST,
@@ -86,13 +88,6 @@ excellent listing. Questions should be relevant to the category:
 - Clothing/Shoes: size, colour, material, sole condition (shoes)?
 - Furniture: dimensions, material, colour?
 - General: cosmetic defects, included accessories, reason for selling?
-
-If photos are already uploaded and the seller's details are too generic, call \
-analyze_images_for_descriptors to enrich the listing from visible evidence. \
-This is especially useful for unbranded or visual items like jewellery, clothing, \
-shoes, watches, furniture, bags, and collectibles. Use cautious wording: do not \
-claim authenticity, precious metals, gemstones, or brand unless visible markings \
-prove them.
 
 Ask ONE question at a time. Keep it conversational and friendly. Aim up \
 to 6 questions total to gather all missing information and every enrinchment \
@@ -285,6 +280,13 @@ async def _plan_next_step(
             True,
             False,
         )
+
+    if not item.visual_condition_analyzed_at:
+        images = list(item.images or [])
+        report = await vision.analyse_item_images(item, images)
+        vision.apply_visual_report_to_item(item, report)
+        item.visual_condition_analyzed_at = datetime.now(UTC)
+        await session.flush()
 
     item.status = ItemStatus.intake_complete
     await session.flush()

--- a/tests/test_intake_graph.py
+++ b/tests/test_intake_graph.py
@@ -315,7 +315,7 @@ async def test_plan_next_step_completes_once_minimum_images_uploaded():
 
 
 @pytest.mark.asyncio
-async def test_plan_next_step_does_not_call_vision_automatically(monkeypatch):
+async def test_plan_next_step_calls_vision_automatically(monkeypatch):
     item_id = uuid.uuid4()
     seller_id = uuid.uuid4()
     item = Item(
@@ -329,8 +329,49 @@ async def test_plan_next_step_does_not_call_vision_automatically(monkeypatch):
     item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
     session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
 
+    fake_report = {
+        "condition_grade": "good",
+        "confidence": 0.85,
+        "visible_defects": [],
+        "visual_descriptors": [],
+        "photo_quality": "clear",
+        "description_addendum": "",
+        "descriptor_addendum": "",
+        "pricing_signals": [],
+        "comparable_include_terms": [],
+        "comparable_exclude_terms": [],
+    }
+    analyse = AsyncMock(return_value=fake_report)
+    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
+    monkeypatch.setattr("packages.agents.intake.graph.vision.apply_visual_report_to_item", lambda *_: None)
+
+    _reply, _needs_image, complete = await _plan_next_step(session, item.id)
+
+    assert complete is True
+    analyse.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_plan_next_step_skips_vision_if_already_analyzed(monkeypatch):
+    """Vision should not re-run if visual_condition_analyzed_at is already set."""
+    from datetime import UTC, datetime
+
+    item_id = uuid.uuid4()
+    seller_id = uuid.uuid4()
+    item = Item(
+        id=item_id,
+        seller_id=seller_id,
+        name="Nike Air Max 90",
+        category="Trainers",
+        condition=ItemCondition.good,
+        description="Nike Air Max 90 trainers in good condition.",
+    )
+    item.images = [_make_image(item_id, seller_id, i) for i in range(_MIN_LISTING_IMAGES)]
+    item.visual_condition_analyzed_at = datetime.now(UTC)
+    session = _FakeSession(item=item, image_count=_MIN_LISTING_IMAGES)
+
     analyse = AsyncMock()
-    monkeypatch.setattr("packages.agents.intake.tools.vision.analyse_item_images", analyse)
+    monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
 
     _reply, _needs_image, complete = await _plan_next_step(session, item.id)
 

--- a/tests/test_intake_graph.py
+++ b/tests/test_intake_graph.py
@@ -343,7 +343,9 @@ async def test_plan_next_step_calls_vision_automatically(monkeypatch):
     }
     analyse = AsyncMock(return_value=fake_report)
     monkeypatch.setattr("packages.agents.intake.graph.vision.analyse_item_images", analyse)
-    monkeypatch.setattr("packages.agents.intake.graph.vision.apply_visual_report_to_item", lambda *_: None)
+    monkeypatch.setattr(
+        "packages.agents.intake.graph.vision.apply_visual_report_to_item", lambda *_: None
+    )
 
     _reply, _needs_image, complete = await _plan_next_step(session, item.id)
 


### PR DESCRIPTION
## Summary

- Removes the prompt instruction that left vision analysis to the LLM's discretion during the intake conversation
- Adds a deterministic `analyse_item_images` call inside `_plan_next_step` immediately before marking intake complete — runs once, skips if `visual_condition_analyzed_at` is already set
- Vision results are applied via `apply_visual_report_to_item` and the timestamp is persisted so re-runs are idempotent

## Test plan

- [x] `test_plan_next_step_calls_vision_automatically` — asserts vision is called exactly once on completion
- [x] `test_plan_next_step_skips_vision_if_already_analyzed` — asserts vision is not re-run when timestamp is set
- [x] All 21 intake graph tests pass (`uv run pytest tests/test_intake_graph.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)